### PR TITLE
"~다만" 어절에서 명사 추출 현상

### DIFF
--- a/soynlp/noun/_noun.py
+++ b/soynlp/noun/_noun.py
@@ -133,7 +133,7 @@ class LRNounExtractor:
             if len(word) <= 1:
                 continue
             features = self._get_r_features(word)
-            score = self.predict(features) if features else self._get_subword_score(nouns, word, minimum_noun_score)
+            score = self.predict(features, word) if features else self._get_subword_score(nouns, word, minimum_noun_score)
             if score[0] < minimum_noun_score:
                 continue
             nouns[word] = score
@@ -169,7 +169,15 @@ class LRNounExtractor:
         features = self._get_r_features(word)
         return self.predict(features)[0] >= minimum_noun_score
 
-    def predict(self, features):
+    def predict(self, features, word):
+        
+        def exist_longer_r_feature(features, word):
+            for e in range(len(word)-1, -1, -1):
+                suffix = word[e:] + features
+                if suffix in self.coefficient: 
+                    return True
+            return False
+        
         """Parameters
         ----------
             features: dict
@@ -182,8 +190,9 @@ class LRNounExtractor:
         
         for r, freq in features.items():
             if r in self.coefficient:
-                score += freq * self.coefficient[r]
-                norm += freq
+                if not exist_longer_r_feature(r, word):  
+                    score += freq * self.coefficient[r]
+                    norm += freq
             else:
                 unknown += freq
         


### PR DESCRIPTION
안녕하세요. 
코드 검토 요청드립니다.

1. 수정 내용

soynlp의 명사 추출 시, 더 긴 r_feature가 있는 경우, 점수 계산식에서 해당 r_feature에 대한 점수를 제외하는 룰 추가

2. 배경

이메일 데이터의 명사를 추출해야하는 일이 있어, soynlp로 진행하였고,
이메일 데이터에는 "감사합니다만", "고맙습니다만"과 같은 "~다만"이라는 어절이 많이 나옵니다.

문제는
만	    0.951425
다만	   -0.953206
{L : "감사합니다", R : {"만" :5000}} 인 경우,
"만"의 r_feature 점수가 높아 "감사합니다", "고맙습니다"가 항상 명사로 추출됩니다.
그러나 "감사합니다"는 명사가 아니고, "다만"의 r_feature의 점수를 보았을때, 추출되면 안되는 명사입니다.

저는 위의 "noun_predictor_sejong"점수를, "만"으로 끝나는 단어 중에 "다만"의 경우 -0.953206을 부여하고, "다만"이 아닌 경우 0.951425를 주자는 의도로 이해했습니다.
"감사합니다" + "만"을 조사하는 과정인데, "다만"의 점수를 적용하는 것도 틀린거 같고, "다만"이 있는데 "만"의 점수를 적용하는 것도 틀린 거같습니다.
그래서 **후보 단어("감사합니다")와 r_feature("만")를 합쳐 더 긴 r_feature("다만")가 있는지 한번더 확인을 하고, 있는 경우에 해당 스코어는 알수 없으므로 스코어 계산에서 제외**하는게 어떨까 싶습니다.

참고로 def **_postprocess**에서 "감사합니다"가 제외되지 않습니다. "감사"라는 명사가 추출 되었더라도 "합니다"라는 r_feature가 없기 때문에 점수를 만족시키지 못하고 추출됩니다.

3. 결과

"감사합니다만", "고맙습니다만"같은 "~다만"의 어절에서 "감사합니다", "고맙습니다"가 추출되지 않음.

가	    0.997334
까	   -0.926375
니까	   -0.880497
부작용으로 { L : "안녕하십니", R : {"까" : 1000, "가" : 1}}과 같은 오타성의 "안녕하십니가" 가 있는 경우, "니까"가 r_feature로 존재하기 때문에, "까"가 제외되고, "가"의 r_feature만으로 점수가 계산되어 "안녕하십니"가 추출 됨.

4. 첨언

def **_postprocess**에서 예외룰로 "감사합니다", "고맙습니다" 등의 단어를 예외시키는 것도 방법인거 같습니다. 다만 로직적으로 더 나은 해결할 방법이 있을지 고민입니다.
"감사합니다"에 집착한 이유는, 실제 한문서에 여러번 나오는 경우가 많아, keyword나 topic 추출 시, 영향을 많이 미친 경험이 있습니다.
