### PR TITLE
fix to_lrgraph function in utils.py

### DIFF
--- a/soynlp/utils/utils.py
+++ b/soynlp/utils/utils.py
@@ -203,7 +203,7 @@ class EojeolCounter:
         return self._counter.items()
 
     def to_lrgraph(self, l_max_length=10, r_max_length=9):
-        return (self._counter, l_max_length, r_max_length)
+        return self._to_lrgraph(self._counter, l_max_length, r_max_length)
 
     def _to_lrgraph(self, counter, l_max_length=10, r_max_length=9):
         _lrgraph = defaultdict(lambda: defaultdict(int))


### PR DESCRIPTION
LRNounExtractor_v2 사용 중에 버그를 발견하여 PR 남깁니다.

get_l 함수가 호출되지않아서 보니 LRgraph 클래스가 아닌 Tuple이 리턴되어서 생긴 에러라고 하네요.

utils/utils.py 의 to_lrgraph 와 _to_lrgraph 를 나누면서 발생한 문제같습니다.
