### PR TITLE
Fix#108

### DIFF
--- a/soynlp/normalizer/_normalizer.py
+++ b/soynlp/normalizer/_normalizer.py
@@ -8,7 +8,7 @@ import re
 from soynlp.hangle import compose, decompose
 
 doublespace_pattern = re.compile('\s+')
-repeatchars_pattern = re.compile('(\w)\\1{3,}')
+repeatchars_pattern = re.compile('(\w)\\1{2,}')
 number_pattern = re.compile('[0-9]')
 punctuation_pattern = re.compile('[,\.\?\!]')
 symbol_pattern = re.compile('[()\[\]\{\}`]')

--- a/soynlp/postagger/_maxscore.py
+++ b/soynlp/postagger/_maxscore.py
@@ -1,0 +1,3 @@
+class MaxScoreTagger:
+    def __init__(self, word_pos):
+        self.word_pos = word_pos

--- a/soynlp/utils/utils.py
+++ b/soynlp/utils/utils.py
@@ -99,6 +99,8 @@ def check_corpus(corpus):
 
 class DoublespaceLineCorpus:    
     def __init__(self, corpus_fname, num_doc = -1, num_sent = -1, iter_sent = False, skip_header = 0):
+        if not os.path.exists(corpus_fname):
+            raise ValueError("File {} does not exist".format(corpus_fname))
         self.corpus_fname = corpus_fname
         self.num_doc = 0
         self.num_sent = 0


### PR DESCRIPTION
- 최소 반복 횟수가 3으로 설정되어 있던 문제 해결

```
- repeatchars_pattern = re.compile('(\w)\\1{3,}')
+ repeatchars_pattern = re.compile('(\w)\\1{2,}')
```