### PR TITLE
Fix #101

### DIFF
--- a/soynlp/utils/utils.py
+++ b/soynlp/utils/utils.py
@@ -224,6 +224,7 @@ class EojeolCounter:
         check_corpus(sents)
 
         _counter = {}
+        i_sent = -1
         for i_sent, sent in enumerate(sents):
             sent = self.preprocess(sent)
             # filtering during eojeol counting


### PR DESCRIPTION
sents 가 없을 때 "0 sents"라고 메시지를 띄우는 것이 맞는 것 같습니다.