### PR TITLE
한자를 포함하는 normalizer

### DIFF
--- a/soynlp/normalizer/__init__.py
+++ b/soynlp/normalizer/__init__.py
@@ -7,6 +7,7 @@ from ._normalizer import only_text
 from ._normalizer import normalize
 from ._normalizer import remain_hangle_on_last
 from ._normalizer import normalize_sent_for_lrgraph
+from ._normalizer import text_with_hanja
 
 __all__ = [
     'normalize',
@@ -17,5 +18,6 @@ __all__ = [
     'only_hangle_number',
     'only_text',
     'remain_hangle_on_last',
-    'normalize_sent_for_lrgraph'
+    'normalize_sent_for_lrgraph',
+    'text_with_hanja'
 ]

--- a/soynlp/normalizer/_normalizer.py
+++ b/soynlp/normalizer/_normalizer.py
@@ -19,6 +19,9 @@ hangle_filter = re.compile('[^ㄱ-ㅎㅏ-ㅣ가-힣]')
 hangle_number_filter = re.compile('[^ㄱ-ㅎㅏ-ㅣ가-힣0-9]')
 text_filter = re.compile('[^ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z0-9,\.\?\!\"\'-()\[\]\{\}]')
 
+# text + 한자 filter
+text_with_hanja_filter = re.compile('[^ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z0-9,\.\?\!\"\'-()\[\]\{\}\u2E80-\u2FDF\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]')
+
 def normalize(doc, alphabet=False, number=False,
     punctuation=False, symbol=False, remove_repeat=0):
 
@@ -110,3 +113,7 @@ def normalize_sent_for_lrgraph(sent):
     if not sent_:
         return ''
     return ' '.join(sent_)
+
+# only_test()에 한자를 추가
+def text_with_hanja(sent):
+    return doublespace_pattern.sub(' ',text_with_hanja_filter.sub(' ', sent)).strip()


### PR DESCRIPTION
안녕하세요.

제가 한자가 포함된 텍스트를 전처리하려고 보니 한자와 한글, 영어, 숫자만 포함시키는 함수가 필요하더라고요.

그래서 유니코드를 사용해서 한자까지 포함시키는 text_with_hanja 함수를 normalizer 안에 넣어 사용중입니다.

이 기능이 필요하실까 싶어 PR을 보내게 되었습니다.

이상입니다. 감사합니다.