### PR TITLE
Fix Python 3.12+ compatibility warnings

### DIFF
--- a/soynlp/hangle/_hangle.py
+++ b/soynlp/hangle/_hangle.py
@@ -38,8 +38,8 @@ jaum_list = ['ㄱ', 'ㄲ', 'ㄳ', 'ㄴ', 'ㄵ', 'ㄶ', 'ㄷ', 'ㄸ', 'ㄹ',
 moum_list = ['ㅏ', 'ㅐ', 'ㅑ', 'ㅒ', 'ㅓ', 'ㅔ', 'ㅕ', 'ㅖ', 'ㅗ', 'ㅘ', 
               'ㅙ', 'ㅚ', 'ㅛ', 'ㅜ', 'ㅝ', 'ㅞ', 'ㅟ', 'ㅠ', 'ㅡ', 'ㅢ', 'ㅣ']
 
-doublespace_pattern = re.compile('\s+')
-repeatchars_pattern = re.compile('(\w)\\1{3,}')
+doublespace_pattern = re.compile(r'\s+')
+repeatchars_pattern = re.compile(r'(\w)\1{3,}')
 
 def normalize(doc, english=False, number=False, punctuation=False, remove_repeat = 0, remains={}):
     message = 'normalize func will be moved soynlp.normalizer at ver 0.1\nargument remains will be removed at ver 0.1'

--- a/soynlp/normalizer/_normalizer.py
+++ b/soynlp/normalizer/_normalizer.py
@@ -7,17 +7,17 @@ if sys.version_info <= (2,7):
 import re
 from soynlp.hangle import compose, decompose
 
-doublespace_pattern = re.compile('\s+')
-repeatchars_pattern = re.compile('(\w)\\1{2,}')
-number_pattern = re.compile('[0-9]')
-punctuation_pattern = re.compile('[,\.\?\!]')
-symbol_pattern = re.compile('[()\[\]\{\}`]')
-hangle_pattern = re.compile('[ㄱ-ㅎㅏ-ㅣ가-힣]')
-alphabet_pattern = re.compile('[a-zA-Z]')
+doublespace_pattern = re.compile(r'\s+')
+repeatchars_pattern = re.compile(r'(\w)\1{2,}')
+number_pattern = re.compile(r'[0-9]')
+punctuation_pattern = re.compile(r'[,.\?!]')
+symbol_pattern = re.compile(r'[()\[\]\{\}`]')
+hangle_pattern = re.compile(r'[ㄱ-ㅎㅏ-ㅣ가-힣]')
+alphabet_pattern = re.compile(r'[a-zA-Z]')
 
-hangle_filter = re.compile('[^ㄱ-ㅎㅏ-ㅣ가-힣]')
-hangle_number_filter = re.compile('[^ㄱ-ㅎㅏ-ㅣ가-힣0-9]')
-text_filter = re.compile('[^ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z0-9,\.\?\!\"\'-()\[\]\{\}]')
+hangle_filter = re.compile(r'[^ㄱ-ㅎㅏ-ㅣ가-힣]')
+hangle_number_filter = re.compile(r'[^ㄱ-ㅎㅏ-ㅣ가-힣0-9]')
+text_filter = re.compile(r'[^ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z0-9,.\?!\"\'\-()\[\]\{\}]')
 
 def normalize(doc, alphabet=False, number=False,
     punctuation=False, symbol=False, remove_repeat=0):

--- a/soynlp/predicator/_predicator.py
+++ b/soynlp/predicator/_predicator.py
@@ -483,10 +483,10 @@ class PredicatorExtractor:
                 # others are extracted stems
                 # rule based classifier, verb preference
                 answer = rule_classify(lemma[0])
-                if answer is 'Verb':
+                if answer == 'Verb':
                     v.add(lemma)
                     continue
-                if answer is 'Adjective':
+                if answer == 'Adjective':
                     adj.add(lemma)
                     continue
 

--- a/soynlp/tokenizer/_normalizer.py
+++ b/soynlp/tokenizer/_normalizer.py
@@ -4,10 +4,10 @@ import re
 from soynlp.hangle import decompose, compose
 
 repeatchars_patterns = [
-    re.compile('(\w\w\w\w)\\1{3,}'),
-    re.compile('(\w\w\w)\\1{3,}'),
-    re.compile('(\w\w)\\1{3,}'),
-    re.compile('(\w)\\1{3,}')
+    re.compile(r'(\w\w\w\w)\1{3,}'),
+    re.compile(r'(\w\w\w)\1{3,}'),
+    re.compile(r'(\w\w)\1{3,}'),
+    re.compile(r'(\w)\1{3,}')
 ]
 
 def normalize(sentence, num_repeat=2):

--- a/soynlp/tokenizer/_tokenizer.py
+++ b/soynlp/tokenizer/_tokenizer.py
@@ -12,14 +12,14 @@ class RegexTokenizer:
     
     def __init__(self):
         self._patterns = [
-            ('number', re.compile(u'[-+]?\d*[\.]?[\d]+|[-+]?\d+', re.UNICODE)),
-            ('korean', re.compile(u'[가-힣]+', re.UNICODE)),
-            ('jaum', re.compile(u'[ㄱ-ㅎ]+', re.UNICODE)),
-            ('moum', re.compile(u'[ㅏ-ㅣ]+', re.UNICODE)),
-            ('english & latin', re.compile(u"[a-zA-ZÀ-ÿ]+[[`']?s]*|[a-zA-ZÀ-ÿ]+", re.UNICODE))
+            ('number', re.compile(r'[-+]?\d*[.]?[\d]+|[-+]?\d+', re.UNICODE)),
+            ('korean', re.compile(r'[가-힣]+', re.UNICODE)),
+            ('jaum', re.compile(r'[ㄱ-ㅎ]+', re.UNICODE)),
+            ('moum', re.compile(r'[ㅏ-ㅣ]+', re.UNICODE)),
+            ('english & latin', re.compile(r"[a-zA-ZÀ-ÿ]+(?:[`']?s)*|[a-zA-ZÀ-ÿ]+", re.UNICODE))
         ]
         
-        self.doublewhite_pattern = re.compile('\s+')
+        self.doublewhite_pattern = re.compile(r'\s+')
 
     def __call__(self, s, debug=True, flatten=True):
         return self.tokenize(s, debug, flatten)


### PR DESCRIPTION
  ---
  - 정규식 패턴에 raw string 적용하여 invalid escape sequence 경고 해결
  - 문자열 리터럴 비교에서 is를 ==로 변경
  - 정규식 패턴의 nested set 경고를 non-capturing group으로 해결

  GitHub 이슈 #156 해결

  ---
  테스트

  Python 3.14 환경

  source .venv/bin/activate
  python -W error -c "import soynlp"  # 경고 없이 import 성공
  PYTHONPATH=. python test/basic_test.py --corpus_path tutorials/doublespace_line_corpus_sample.txt
  - ✅ 경고 없이 import 성공
  - ✅ basic_test.py 전체 통과 (hangle, tokenizer, word extractor, noun extractor, pos tagger, pmi)

  Python 2.7 환경

  ~/.pyenv/versions/2.7.18/bin/python -c "
  import re
  patterns = [
      re.compile(r'\s+'),
      re.compile(r'(\w)\1{2,}'),
      re.compile(r'[-+]?\d*[.]?[\d]+|[-+]?\d+'),
  ]
  answer = 'Verb'
  assert answer == 'Verb'
  print('All tests passed!')
  "
  - ✅ raw string 정규식 패턴 정상 동작
  - ✅ == 연산자 정상 동작

  ---