### PR TITLE
perf(predicator): PredicatorExtractor 멀티프로세싱 지원

### DIFF
--- a/soynlp/predicator/predicator.py
+++ b/soynlp/predicator/predicator.py
@@ -148,6 +148,7 @@ class PredicatorExtractor:
         min_entropy_of_R: float = 1.5,
         min_stem_score: float = 0.7,
         min_stem_frequency: int = 100,
+        n_workers: int = 1,
     ):
         self.train(
             inputs,
@@ -161,6 +162,7 @@ class PredicatorExtractor:
             min_entropy_of_R,
             min_stem_score,
             min_stem_frequency,
+            n_workers=n_workers,
         )
         return self.extract(candidates, min_predicator_frequency)
 
@@ -177,13 +179,14 @@ class PredicatorExtractor:
         min_entropy_of_R: float = 1.5,
         min_stem_score: float = 0.7,
         min_stem_frequency: int = 100,
+        n_workers: int = 1,
     ):
         if isinstance(inputs, LRGraph):
             self._train_with_eojeol_counter(inputs.to_EojeolCounter(), min_eojeol_frequency)  # type: ignore[union-attr]
         elif isinstance(inputs, EojeolCounter):
             self._train_with_eojeol_counter(inputs, min_eojeol_frequency)
         else:
-            self._train_with_sentences(inputs, min_eojeol_frequency, filtering_checkpoint)
+            self._train_with_sentences(inputs, min_eojeol_frequency, filtering_checkpoint, n_workers=n_workers)
 
         if self.extract_eomi or self.extract_stem:
             lrgraph = self._prepare_predicator_lrgraph()
@@ -205,7 +208,9 @@ class PredicatorExtractor:
 
         logger.info("has been trained")
 
-    def _train_with_sentences(self, sentences, min_eojeol_frequency: int = 2, filtering_checkpoint: int = 100000):
+    def _train_with_sentences(
+        self, sentences, min_eojeol_frequency: int = 2, filtering_checkpoint: int = 100000, n_workers: int = 1
+    ):
         logger.info("counting eojeols ...")
 
         preprocess = (lambda x: x) if self.ensure_normalized else normalize_sent_for_lrgraph
@@ -215,6 +220,7 @@ class PredicatorExtractor:
             min_count=min_eojeol_frequency,
             verbose=self.verbose,
             preprocess=preprocess,
+            n_workers=n_workers,
         )
         self._train_with_eojeol_counter(eojeol_counter)
 

--- a/soynlp/utils/utils.py
+++ b/soynlp/utils/utils.py
@@ -199,6 +199,7 @@ class EojeolCounter:
         self.verbose = verbose
         self.text_key = text_key
 
+        self._has_custom_preprocess = preprocess is not None
         if preprocess is None:
 
             def base_preprocessing(x: str) -> str:

--- a/soynlp/utils/utils.py
+++ b/soynlp/utils/utils.py
@@ -16,12 +16,14 @@ logger = logging.getLogger(__name__)
 installpath = os.path.sep.join(os.path.dirname(os.path.realpath(__file__)).split(os.path.sep)[:-1])
 
 
-def _count_eojeol_chunk(args: tuple[list, int, str]) -> dict[str, int]:
+def _count_eojeol_chunk(args: tuple) -> dict[str, int]:
     """Worker function for parallel eojeol counting. Must be module-level for pickling."""
-    chunk, max_length, text_key = args
+    chunk, max_length, text_key, preprocess = args
     counter: dict[str, int] = {}
     for item in chunk:
         sent = item[text_key] if isinstance(item, dict) else item
+        if preprocess is not None:
+            sent = preprocess(sent)
         for eojeol in sent.split():
             if (not eojeol) or (len(eojeol) > max_length):
                 continue
@@ -204,6 +206,15 @@ class EojeolCounter:
                 return x
 
             preprocess = base_preprocessing
+            self._parallel_preprocess: Callable[[str], str] | None = None
+        else:
+            import pickle
+
+            try:
+                pickle.dumps(preprocess)
+                self._parallel_preprocess = preprocess
+            except (pickle.PicklingError, AttributeError):
+                self._parallel_preprocess = None
         self.preprocess = preprocess
 
         if sents is not None:
@@ -226,10 +237,10 @@ class EojeolCounter:
 
     def _counting_from_sents(self, sents: Any, n_workers: int = 1) -> dict[str, int]:
         check_corpus(sents)
-        if n_workers != 1 and not self._has_custom_preprocess:
-            return self._counting_from_sents_parallel(sents, n_workers)
-        if n_workers != 1 and self._has_custom_preprocess:
-            logger.info("EojeolCounter: custom preprocess는 멀티프로세싱 미지원 — 단일 프로세스로 집계")
+        if n_workers != 1 and (not self._has_custom_preprocess or self._parallel_preprocess is not None):
+            return self._counting_from_sents_parallel(sents, n_workers, self._parallel_preprocess)
+        if n_workers != 1:
+            logger.info("EojeolCounter: custom preprocess가 pickle 불가 — 단일 프로세스로 집계")
         if self.verbose:
             sent_iterator = tqdm(sents, desc="[EojeolCounter] counting eojeols ", total=len(sents))
         else:
@@ -250,14 +261,16 @@ class EojeolCounter:
         counter = {eojeol: count for eojeol, count in counter.items() if count >= self.min_count}
         return counter
 
-    def _counting_from_sents_parallel(self, sents: Any, n_workers: int) -> dict[str, int]:
+    def _counting_from_sents_parallel(
+        self, sents: Any, n_workers: int, preprocess: Callable[[str], str] | None = None
+    ) -> dict[str, int]:
         from multiprocessing import Pool, cpu_count
 
         texts = list(sents)
         n = cpu_count() if n_workers == -1 else n_workers
         chunk_size = max(1, len(texts) // n)
         chunks = [texts[i : i + chunk_size] for i in range(0, len(texts), chunk_size)]
-        worker_args = [(chunk, self.max_length, self.text_key) for chunk in chunks]
+        worker_args = [(chunk, self.max_length, self.text_key, preprocess) for chunk in chunks]
 
         with Pool(processes=n) as pool:
             partial_counters = pool.map(_count_eojeol_chunk, worker_args)

--- a/soynlp/utils/utils.py
+++ b/soynlp/utils/utils.py
@@ -16,6 +16,19 @@ logger = logging.getLogger(__name__)
 installpath = os.path.sep.join(os.path.dirname(os.path.realpath(__file__)).split(os.path.sep)[:-1])
 
 
+def _count_eojeol_chunk(args: tuple[list, int, str]) -> dict[str, int]:
+    """Worker function for parallel eojeol counting. Must be module-level for pickling."""
+    chunk, max_length, text_key = args
+    counter: dict[str, int] = {}
+    for item in chunk:
+        sent = item[text_key] if isinstance(item, dict) else item
+        for eojeol in sent.split():
+            if (not eojeol) or (len(eojeol) > max_length):
+                continue
+            counter[eojeol] = counter.get(eojeol, 0) + 1
+    return counter
+
+
 def get_available_memory() -> float:
     """It returns remained memory as percentage"""
     mem = psutil.virtual_memory()
@@ -176,6 +189,7 @@ class EojeolCounter:
         verbose: bool = False,
         preprocess: Callable[[str], str] | None = None,
         text_key: str = "text",
+        n_workers: int = 1,
     ) -> None:
         self.min_count = min_count
         self.max_length = max_length
@@ -192,7 +206,7 @@ class EojeolCounter:
         self.preprocess = preprocess
 
         if sents is not None:
-            self._counter = self._counting_from_sents(sents)
+            self._counter = self._counting_from_sents(sents, n_workers=n_workers)
         else:
             self._counter = {}
 
@@ -209,13 +223,18 @@ class EojeolCounter:
     def __len__(self) -> int:
         return len(self._counter)
 
-    def _counting_from_sents(self, sents: Any) -> dict[str, int]:
+    def _counting_from_sents(self, sents: Any, n_workers: int = 1) -> dict[str, int]:
         check_corpus(sents)
+        use_custom_preprocess = self.preprocess.__name__ != "base_preprocessing"
+        if n_workers != 1 and not use_custom_preprocess:
+            return self._counting_from_sents_parallel(sents, n_workers)
+        if n_workers != 1 and use_custom_preprocess:
+            logger.info("EojeolCounter: custom preprocess는 멀티프로세싱 미지원 — 단일 프로세스로 집계")
         if self.verbose:
             sent_iterator = tqdm(sents, desc="[EojeolCounter] counting eojeols ", total=len(sents))
         else:
             sent_iterator = sents
-        counter = {}
+        counter: dict[str, int] = {}
         for i_sent, item in enumerate(sent_iterator):
             if isinstance(item, dict):
                 sent = item[self.text_key]
@@ -230,6 +249,24 @@ class EojeolCounter:
                 counter[eojeol] = counter.get(eojeol, 0) + 1
         counter = {eojeol: count for eojeol, count in counter.items() if count >= self.min_count}
         return counter
+
+    def _counting_from_sents_parallel(self, sents: Any, n_workers: int) -> dict[str, int]:
+        from multiprocessing import Pool, cpu_count
+
+        texts = list(sents)
+        n = cpu_count() if n_workers == -1 else n_workers
+        chunk_size = max(1, len(texts) // n)
+        chunks = [texts[i : i + chunk_size] for i in range(0, len(texts), chunk_size)]
+        worker_args = [(chunk, self.max_length, self.text_key) for chunk in chunks]
+
+        with Pool(processes=n) as pool:
+            partial_counters = pool.map(_count_eojeol_chunk, worker_args)
+
+        merged: dict[str, int] = {}
+        for partial in partial_counters:
+            for eojeol, count in partial.items():
+                merged[eojeol] = merged.get(eojeol, 0) + count
+        return {eojeol: count for eojeol, count in merged.items() if count >= self.min_count}
 
     def remove_eojeols(self, eojeols: set[str] | str) -> "EojeolCounter":
         """Remove eojeols

--- a/soynlp/utils/utils.py
+++ b/soynlp/utils/utils.py
@@ -197,6 +197,7 @@ class EojeolCounter:
         self.verbose = verbose
         self.text_key = text_key
 
+        self._has_custom_preprocess = preprocess is not None
         if preprocess is None:
 
             def base_preprocessing(x: str) -> str:
@@ -225,10 +226,9 @@ class EojeolCounter:
 
     def _counting_from_sents(self, sents: Any, n_workers: int = 1) -> dict[str, int]:
         check_corpus(sents)
-        use_custom_preprocess = self.preprocess.__name__ != "base_preprocessing"
-        if n_workers != 1 and not use_custom_preprocess:
+        if n_workers != 1 and not self._has_custom_preprocess:
             return self._counting_from_sents_parallel(sents, n_workers)
-        if n_workers != 1 and use_custom_preprocess:
+        if n_workers != 1 and self._has_custom_preprocess:
             logger.info("EojeolCounter: custom preprocess는 멀티프로세싱 미지원 — 단일 프로세스로 집계")
         if self.verbose:
             sent_iterator = tqdm(sents, desc="[EojeolCounter] counting eojeols ", total=len(sents))

--- a/soynlp/utils/utils.py
+++ b/soynlp/utils/utils.py
@@ -199,7 +199,6 @@ class EojeolCounter:
         self.verbose = verbose
         self.text_key = text_key
 
-        self._has_custom_preprocess = preprocess is not None
         if preprocess is None:
 
             def base_preprocessing(x: str) -> str:

--- a/tests/unit/test_predicator.py
+++ b/tests/unit/test_predicator.py
@@ -163,3 +163,37 @@ class TestPredicatorExtractor:
         # "아름답" has suffix "답" -> should be classified as adjective
         adj, verb = extractor._separate_adjective_verb(predicators)
         assert "아름다워" in adj
+
+
+_PREDICATOR_SENTS = [
+    "사과가 맛있습니다",
+    "바나나를 먹었습니다",
+    "사과를 먹고 바나나도 먹었습니다",
+    "공부하는 학생들이 많습니다",
+    "열심히 공부합니다",
+] * 100
+
+
+class TestPredicatorExtractorMultiprocessing:
+    def test_train_with_sentences_n_workers_accepted(self):
+        """n_workers 파라미터가 에러 없이 수용되고 eojeol_counter가 구축된다."""
+        from soynlp.predicator import PredicatorExtractor
+
+        extractor = PredicatorExtractor(nouns={"사과", "바나나"}, verbose=False)
+        extractor.train(_PREDICATOR_SENTS, n_workers=4)
+        assert extractor.eojeol_counter is not None
+        assert len(extractor.eojeol_counter) > 0
+
+    def test_train_multi_eojeol_counter_same_as_single(self):
+        """n_workers=4로 구축한 EojeolCounter가 단일 프로세스와 동일하다."""
+        from soynlp.predicator import PredicatorExtractor
+
+        ext_single = PredicatorExtractor(nouns={"사과", "바나나"}, verbose=False)
+        ext_single.train(_PREDICATOR_SENTS, n_workers=1)
+
+        ext_multi = PredicatorExtractor(nouns={"사과", "바나나"}, verbose=False)
+        ext_multi.train(_PREDICATOR_SENTS, n_workers=4)
+
+        assert ext_single.eojeol_counter is not None
+        assert ext_multi.eojeol_counter is not None
+        assert dict(ext_single.eojeol_counter.items()) == dict(ext_multi.eojeol_counter.items())

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -235,3 +235,35 @@ def test_corpus_loader_with_eojeol_counter(jsonl_file):
     counter = EojeolCounter(sents=loader)
     assert counter["이것은"] == 1
     assert counter["예문입니다"] == 1
+
+
+# --- EojeolCounter multiprocessing tests ---
+
+_MULTI_SENTS = [
+    "아이오아이가 평가단에게 높은 점수를 받았습니다",
+    "아이오아이는 아이돌 그룹입니다",
+    "자연어처리는 어렵습니다",
+    "자연어처리를 공부합니다",
+    "명사추출은 중요한 작업입니다",
+] * 100
+
+
+def test_eojeol_counter_multi_equals_single():
+    """n_workers=4 결과가 단일 프로세스 결과와 동일하다."""
+    single = EojeolCounter(sents=_MULTI_SENTS, n_workers=1)
+    multi = EojeolCounter(sents=_MULTI_SENTS, n_workers=4)
+    assert dict(single.items()) == dict(multi.items())
+
+
+def test_eojeol_counter_auto_workers():
+    """n_workers=-1이면 CPU 코어 수를 자동 사용한다."""
+    single = EojeolCounter(sents=_MULTI_SENTS, n_workers=1)
+    auto = EojeolCounter(sents=_MULTI_SENTS, n_workers=-1)
+    assert dict(single.items()) == dict(auto.items())
+
+
+def test_eojeol_counter_multi_with_min_count():
+    """n_workers > 1일 때 min_count 필터가 올바르게 적용된다."""
+    single = EojeolCounter(sents=_MULTI_SENTS, min_count=5, n_workers=1)
+    multi = EojeolCounter(sents=_MULTI_SENTS, min_count=5, n_workers=4)
+    assert dict(single.items()) == dict(multi.items())


### PR DESCRIPTION
## 개요

Closes #163

`PredicatorExtractor.train()`에 `n_workers` 파라미터를 추가하고, `EojeolCounter` 집계 단계를 병렬화합니다.

## 의존 관계

- **의존**: #162 (EojeolCounter 멀티프로세싱) — 이 PR은 feature/162 위에서 작성되었습니다. PR #169가 먼저 머지되어야 합니다.

## 변경 내용

### `soynlp/utils/utils.py`
- `_count_eojeol_chunk()`: `preprocess` 인자 추가 — module-level 함수이면 worker에서 직접 적용
- `EojeolCounter.__init__`: `_parallel_preprocess` 속성 도입 — pickle 가능 여부 자동 판단
- `_counting_from_sents()`: pickle 가능한 custom preprocess도 병렬 경로 허용
- `_counting_from_sents_parallel()`: `preprocess` 파라미터 전달

### `soynlp/predicator/predicator.py`
- `train_extract()`, `train()`, `_train_with_sentences()`에 `n_workers=1` 파라미터 추가
- `EojeolCounter` 생성 시 `n_workers` pass-through
- `ensure_normalized=False`(기본값) 시 `normalize_sent_for_lrgraph`(module-level 함수)가 worker에서 실행됨
- `ensure_normalized=True` 시 lambda 사용 → pickle 불가 → 단일 프로세스 폴백

### `tests/unit/test_predicator.py`
- `TestPredicatorExtractorMultiprocessing` 클래스 추가
  - `n_workers=4` 수용 테스트
  - 멀티/단일 `EojeolCounter` 결과 동일성 검증