### PR TITLE
perf(vectorizer): BaseVectorizer fit() 멀티프로세싱 지원

### DIFF
--- a/soynlp/vectorizer/vectorizer.py
+++ b/soynlp/vectorizer/vectorizer.py
@@ -8,10 +8,28 @@ from scipy.sparse import csr_matrix
 logger = logging.getLogger(__name__)
 
 
+def _default_split_tokenizer(doc: str) -> list[str]:
+    """Default module-level tokenizer for multiprocessing (pickle-able)."""
+    return doc.split()
+
+
+def _fit_chunk(args: tuple) -> tuple[dict[str, int], dict[str, int]]:
+    """Worker: compute partial df/tf for a chunk of documents."""
+    chunk, tokenizer = args
+    df: dict[str, int] = {}
+    tf: dict[str, int] = {}
+    for doc in chunk:
+        counter = Counter(tokenizer(doc))
+        for term, freq in counter.items():
+            df[term] = df.get(term, 0) + 1
+            tf[term] = tf.get(term, 0) + freq
+    return df, tf
+
+
 class BaseVectorizer:
     def __init__(
         self,
-        tokenizer: Callable[[str], list[str]] = lambda x: x.split(),
+        tokenizer: Callable[[str], list[str]] = _default_split_tokenizer,
         min_tf: int = 0,
         max_tf: int = 99999999,
         min_df: float = 0,
@@ -42,27 +60,17 @@ class BaseVectorizer:
         self.idx2vocab: list[str] = []  # 인덱스 → 어휘 역매핑
         self.n_vocabs: int = 0  # 어휘 크기 (= len(idx2vocab))
 
-    def fit_transform(self, docs: list[str]) -> csr_matrix:
-        self.fit(docs)
+    def fit_transform(self, docs: list[str], n_workers: int = 1) -> csr_matrix:
+        self.fit(docs, n_workers=n_workers)
         return self.transform(docs)
 
-    def fit(self, docs: list[str]) -> "BaseVectorizer":
-        df: dict[str, int] = {}
-        tf: dict[str, int] = {}
+    def fit(self, docs: list[str], n_workers: int = 1) -> "BaseVectorizer":
+        if n_workers != 1:
+            df, tf = self._fit_parallel(docs, n_workers)
+        else:
+            df, tf = self._fit_sequential(docs)
 
-        i_doc = 0
-        for i_doc, doc in enumerate(docs):
-            if i_doc % self._check_points == 0:
-                logger.info("scanned %d docs", i_doc)
-
-            counter = Counter(token for token in self.tokenizer(doc))
-            for term, freq in counter.items():
-                df[term] = df.get(term, 0) + 1
-                tf[term] = tf.get(term, 0) + freq
-
-        logger.info("scanning was done")
-
-        n_docs = i_doc + 1
+        n_docs = len(docs)
         min_df = int(n_docs * self.min_df)
         max_df = int(n_docs * self.max_df)
         df = {term: df_t for term, df_t in df.items() if min_df <= df_t <= max_df}
@@ -76,6 +84,47 @@ class BaseVectorizer:
         logger.info("%d terms are recognized", self.n_vocabs)
 
         return self
+
+    def _fit_sequential(self, docs: list[str]) -> tuple[dict[str, int], dict[str, int]]:
+        df: dict[str, int] = {}
+        tf: dict[str, int] = {}
+        for i_doc, doc in enumerate(docs):
+            if i_doc % self._check_points == 0:
+                logger.info("scanned %d docs", i_doc)
+            counter = Counter(self.tokenizer(doc))
+            for term, freq in counter.items():
+                df[term] = df.get(term, 0) + 1
+                tf[term] = tf.get(term, 0) + freq
+        logger.info("scanning was done")
+        return df, tf
+
+    def _fit_parallel(self, docs: list[str], n_workers: int) -> tuple[dict[str, int], dict[str, int]]:
+        import pickle
+        from multiprocessing import Pool, cpu_count
+
+        try:
+            pickle.dumps(self.tokenizer)
+            tok = self.tokenizer
+        except (pickle.PicklingError, AttributeError):
+            logger.info("BaseVectorizer: tokenizer가 pickle 불가 — 단일 프로세스로 fit")
+            return self._fit_sequential(docs)
+
+        n = cpu_count() if n_workers == -1 else n_workers
+        chunk_size = max(1, len(docs) // n)
+        chunks = [docs[i : i + chunk_size] for i in range(0, len(docs), chunk_size)]
+        worker_args = [(chunk, tok) for chunk in chunks]
+
+        with Pool(processes=n) as pool:
+            results = pool.map(_fit_chunk, worker_args)
+
+        df: dict[str, int] = {}
+        tf: dict[str, int] = {}
+        for pDF, pTF in results:
+            for k, v in pDF.items():
+                df[k] = df.get(k, 0) + v
+            for k, v in pTF.items():
+                tf[k] = tf.get(k, 0) + v
+        return df, tf
 
     def transform(self, docs: list[str]) -> csr_matrix:
         rows: list[int] = []

--- a/tests/unit/test_vectorizer.py
+++ b/tests/unit/test_vectorizer.py
@@ -63,6 +63,36 @@ class TestBaseVectorizer:
             assert count >= 2
 
 
+_VECTORIZER_DOCS = [
+    "나는 학생 입니다",
+    "나는 사과를 먹었다",
+    "학생이 사과를 먹었다",
+    "나는 나는 학생 학생",
+] * 200
+
+
+class TestBaseVectorizerMultiprocessing:
+    def test_fit_multi_equals_single(self):
+        """n_workers=4로 fit한 vocabulary가 단일 프로세스와 동일하다."""
+        vec_single = BaseVectorizer(min_tf=0, verbose=False)
+        vec_single.fit(_VECTORIZER_DOCS, n_workers=1)
+
+        vec_multi = BaseVectorizer(min_tf=0, verbose=False)
+        vec_multi.fit(_VECTORIZER_DOCS, n_workers=4)
+
+        assert vec_single.vocabulary_ == vec_multi.vocabulary_
+
+    def test_fit_transform_multi(self):
+        """n_workers=4 fit_transform이 에러 없이 동작하고 같은 모양의 행렬을 반환한다."""
+        vec_single = BaseVectorizer(min_tf=0, verbose=False)
+        x_single = vec_single.fit_transform(_VECTORIZER_DOCS)
+
+        vec_multi = BaseVectorizer(min_tf=0, verbose=False)
+        x_multi = vec_multi.fit_transform(_VECTORIZER_DOCS, n_workers=4)
+
+        assert x_single.shape == x_multi.shape  # type: ignore[index]
+
+
 class TestSentToWordContextsMatrix:
     def test_basic(self):
         sents = ["a b c d e"] * 20


### PR DESCRIPTION
## 개요

Closes #167

`BaseVectorizer.fit()`에 `n_workers` 파라미터를 추가하여 df/tf 집계 단계를 병렬화합니다.

## 의존 관계

- 독립적 — 다른 이슈에 의존하지 않음

## 변경 내용

### `soynlp/vectorizer/vectorizer.py`
- `_default_split_tokenizer()`: 기본 tokenizer를 lambda → module-level 함수로 변경 (pickle 가능)
- `_fit_chunk()`: 모듈 레벨 worker — 청크별 df/tf 집계
- `BaseVectorizer.fit()`: `n_workers=1` 파라미터 추가, sequential/parallel 분기
- `BaseVectorizer.fit_transform()`: `n_workers` pass-through
- `_fit_sequential()`: 기존 순차 로직 분리
- `_fit_parallel()`: Pool.map으로 df/tf 병렬 집계 후 병합
  - custom tokenizer가 pickle 불가하면 단일 프로세스 폴백

### `tests/unit/test_vectorizer.py`
- `TestBaseVectorizerMultiprocessing` 클래스 추가
  - `test_fit_multi_equals_single()`: vocabulary 동일성 검증
  - `test_fit_transform_multi()`: 행렬 shape 동일성 검증

## 특이사항

- 기본 tokenizer를 lambda에서 module-level 함수로 변경 — 외부 API 변경 없음
- `transform()`은 vocabulary_가 필요하므로 fit() 이후에만 의미가 있어 별도 병렬화 불필요