### PR TITLE
fix(tokenizer): RegexTokenizer nested set regex FutureWarning 수정

### DIFF
--- a/soynlp/tokenizer/tokenizer.py
+++ b/soynlp/tokenizer/tokenizer.py
@@ -67,7 +67,7 @@ class RegexTokenizer:
             re.compile(r"[가-힣]+", re.UNICODE),  # Korean
             re.compile(r"[ㄱ-ㅎ]+", re.UNICODE),  # jaum
             re.compile(r"[ㅏ-ㅣ]+", re.UNICODE),  # moum
-            re.compile(r"[a-zA-ZÀ-ÿ]+[[`']{1,1}s]*|[a-zA-ZÀ-ÿ]+", re.UNICODE),  # Alphabet
+            re.compile(r"[a-zA-ZÀ-ÿ]+(?:[`']s)?", re.UNICODE),  # Alphabet (optional 's possessive)
         ]
 
     def __call__(self, sentence, return_words=True):


### PR DESCRIPTION
Closes #176

## 변경 내용

`RegexTokenizer._default_pipelines()`의 알파벳 패턴에서 nested set이 FutureWarning을 발생시키는 문제를 수정.

```python
# Before
re.compile(r"[a-zA-ZÀ-ÿ]+[['`]{1,1}s]*|[a-zA-ZÀ-ÿ]+", re.UNICODE)
# ↑ [['`]{1,1}s] → nested set → FutureWarning (Python 미래 버전에서 SyntaxError)

# After
re.compile(r"[a-zA-ZÀ-ÿ]+(?:['`]s)?", re.UNICODE)
# ↑ non-capturing group으로 교체, 동작 동일 (hank`s, user's 등 소유격 처리)
```

중복 대안 `|[a-zA-ZÀ-ÿ]+`도 제거 (선택적 접미사 `?`로 충분).

## 테스트

- `tests/unit/test_tokenizers.py`: 8 passed, 0 warnings