### PR TITLE
feat(pipeline): ExtractNounTask에 n_workers 파라미터 추가

### DIFF
--- a/soynlp/pipeline/tasks/extract_nouns.py
+++ b/soynlp/pipeline/tasks/extract_nouns.py
@@ -22,6 +22,7 @@ class ExtractNounTaskArgs(TaskArgs):
     in_key: str = "corpus"
     text_key: str = "text"
     out_key: str = "nouns"
+    n_workers: int = 1
 
 
 class ExtractNounTask(Task[ExtractNounTaskArgs]):
@@ -49,6 +50,7 @@ class ExtractNounTask(Task[ExtractNounTaskArgs]):
             extract_compounds=self._args.extract_compounds,
             exclude_syllables=self._args.exclude_syllables,
             exclude_numbers=self._args.exclude_numbers,
+            n_workers=self._args.n_workers,
         )
 
         parameters[self._args.out_key] = nouns

--- a/tests/unit/pipeline/tasks/test_extract_nouns.py
+++ b/tests/unit/pipeline/tasks/test_extract_nouns.py
@@ -16,3 +16,13 @@ class TestExtractNounTask:
         result = task({"corpus": examples})
         assert "nouns" in result
         assert isinstance(result["nouns"], dict)
+
+    @pytest.mark.slow
+    def test_extract_nouns_n_workers(self):
+        """n_workers=2로 실행해도 결과가 동일하다."""
+        examples = [{"text": "이것은 예문입니다"}] * 200
+        task_single = ExtractNounTask(ExtractNounTaskArgs(verbose=False, extract_compounds=False, n_workers=1))
+        task_multi = ExtractNounTask(ExtractNounTaskArgs(verbose=False, extract_compounds=False, n_workers=2))
+        result_single = task_single({"corpus": examples})
+        result_multi = task_multi({"corpus": examples})
+        assert set(result_single["nouns"].keys()) == set(result_multi["nouns"].keys())


### PR DESCRIPTION
## Summary

- `ExtractNounTaskArgs`에 `n_workers: int = 1` 필드 추가
- `ExtractNounTask.__call__()`에서 `extractor.extract()` 호출 시 `n_workers` 전달
- 단일/멀티 프로세스 결과 동일성을 검증하는 `test_extract_nouns_n_workers` 테스트 추가

## Closes

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)