### PR TITLE
perf(vectorizer): sent_to_word_contexts_matrix() n_workers 멀티프로세싱 지원

### DIFF
--- a/soynlp/vectorizer/word_context.py
+++ b/soynlp/vectorizer/word_context.py
@@ -1,4 +1,6 @@
 import logging
+import multiprocessing
+import pickle
 from collections import defaultdict
 from collections.abc import Callable
 
@@ -9,25 +11,70 @@ from soynlp.utils import get_process_memory
 logger = logging.getLogger(__name__)
 
 
+def _default_tokenizer(sent: str) -> list[str]:
+    return sent.split()
+
+
+def _scan_vocab_chunk(args: tuple) -> dict[str, int]:
+    chunk, tokenizer = args
+    counter: dict[str, int] = {}
+    for sent in chunk:
+        for word in tokenizer(sent):
+            counter[word] = counter.get(word, 0) + 1
+    return counter
+
+
+def _word_context_chunk(args: tuple) -> list[tuple[str, str, float]]:
+    chunk, windows, tokenizer, dynamic_weight, vocab2idx = args
+    weight = [(windows - i) / windows for i in range(windows)] if dynamic_weight else [1.0] * windows
+    pairs: list[tuple[str, str, float]] = []
+    for sent in chunk:
+        words = tokenizer(sent)
+        if not words:
+            continue
+        n = len(words)
+        for i, word in enumerate(words):
+            if word not in vocab2idx:
+                continue
+            for w in range(windows):
+                j = i - (w + 1)
+                if j >= 0 and words[j] in vocab2idx:
+                    pairs.append((word, words[j], weight[w]))
+            for w in range(windows):
+                j = i + w + 1
+                if j < n and words[j] in vocab2idx:
+                    pairs.append((word, words[j], weight[w]))
+    return pairs
+
+
 def sent_to_word_contexts_matrix(
     sents: list[str],
     windows: int = 3,
     min_tf: int = 10,
-    tokenizer: Callable[[str], list[str]] = lambda x: x.split(),
+    tokenizer: Callable[[str], list[str]] = _default_tokenizer,
     dynamic_weight: bool = False,
     verbose: bool = True,
+    n_workers: int = 1,
 ) -> tuple[csr_matrix, list[str]]:
     """Create (word, contexts) co-occurrence matrix.
 
     Args:
         dynamic_weight: Use dynamic weight if True.
             co-occurrence weight = [1, (w-1)/w, (w-2)/w, ... 1/w]
+        n_workers: Number of worker processes. Falls back to 1 if tokenizer is not picklable.
     """
     logger.info("Create (word, contexts) matrix")
 
-    vocab2idx, idx2vocab = _scanning_vocabulary(sents, min_tf, tokenizer)
+    if n_workers != 1:
+        try:
+            pickle.dumps(tokenizer)
+        except (pickle.PicklingError, AttributeError):
+            logger.info("sent_to_word_contexts_matrix: tokenizer가 pickle 불가 — 단일 프로세스로 실행")
+            n_workers = 1
 
-    word2contexts = _word_context(sents, windows, tokenizer, dynamic_weight, vocab2idx)
+    vocab2idx, idx2vocab = _scanning_vocabulary(sents, min_tf, tokenizer, n_workers)
+
+    word2contexts = _word_context(sents, windows, tokenizer, dynamic_weight, vocab2idx, n_workers)
 
     x = _encode_as_matrix(word2contexts, vocab2idx)
 
@@ -39,7 +86,11 @@ def _scanning_vocabulary(
     sents: list[str],
     min_tf: int,
     tokenizer: Callable[[str], list[str]],
+    n_workers: int = 1,
 ) -> tuple[dict[str, int], list[str]]:
+    if n_workers != 1:
+        return _scanning_vocabulary_parallel(sents, min_tf, tokenizer, n_workers)
+
     word_counter: dict[str, int] = defaultdict(int)
 
     i_sent = 0
@@ -53,10 +104,34 @@ def _scanning_vocabulary(
 
     _log_status("  - counting word frequency", i_sent)
 
+    return _build_vocab(word_counter, min_tf)
+
+
+def _scanning_vocabulary_parallel(
+    sents: list[str],
+    min_tf: int,
+    tokenizer: Callable[[str], list[str]],
+    n_workers: int,
+) -> tuple[dict[str, int], list[str]]:
+    chunk_size = max(1, len(sents) // n_workers)
+    chunks = [sents[i : i + chunk_size] for i in range(0, len(sents), chunk_size)]
+    args = [(chunk, tokenizer) for chunk in chunks]
+
+    with multiprocessing.Pool(n_workers) as pool:
+        partial_counters = pool.map(_scan_vocab_chunk, args)
+
+    word_counter: dict[str, int] = {}
+    for counter in partial_counters:
+        for word, count in counter.items():
+            word_counter[word] = word_counter.get(word, 0) + count
+
+    return _build_vocab(word_counter, min_tf)
+
+
+def _build_vocab(word_counter: dict[str, int], min_tf: int) -> tuple[dict[str, int], list[str]]:
     vocab2idx = {word for word, count in word_counter.items() if count >= min_tf}
     vocab2idx_map = {word: idx for idx, word in enumerate(sorted(vocab2idx, key=lambda w: -word_counter[w]))}
     idx2vocab = [word for word, _ in sorted(vocab2idx_map.items(), key=lambda w: w[1])]
-
     return vocab2idx_map, idx2vocab
 
 
@@ -70,7 +145,11 @@ def _word_context(
     tokenizer: Callable[[str], list[str]],
     dynamic_weight: bool,
     vocab2idx: dict[str, int],
+    n_workers: int = 1,
 ) -> dict[str, dict[str, float]]:
+    if n_workers != 1:
+        return _word_context_parallel(sents, windows, tokenizer, dynamic_weight, vocab2idx, n_workers)
+
     word2contexts: dict[str, dict[str, float]] = defaultdict(lambda: defaultdict(float))
 
     if dynamic_weight:
@@ -106,6 +185,29 @@ def _word_context(
                 word2contexts[word][words[j]] += weight[w]
 
     _log_status("  - scanning (word, context) pairs", i_sent)
+
+    return word2contexts
+
+
+def _word_context_parallel(
+    sents: list[str],
+    windows: int,
+    tokenizer: Callable[[str], list[str]],
+    dynamic_weight: bool,
+    vocab2idx: dict[str, int],
+    n_workers: int,
+) -> dict[str, dict[str, float]]:
+    chunk_size = max(1, len(sents) // n_workers)
+    chunks = [sents[i : i + chunk_size] for i in range(0, len(sents), chunk_size)]
+    args = [(chunk, windows, tokenizer, dynamic_weight, vocab2idx) for chunk in chunks]
+
+    with multiprocessing.Pool(n_workers) as pool:
+        partial_pairs = pool.map(_word_context_chunk, args)
+
+    word2contexts: dict[str, dict[str, float]] = defaultdict(lambda: defaultdict(float))
+    for pairs in partial_pairs:
+        for word, context, weight in pairs:
+            word2contexts[word][context] += weight
 
     return word2contexts
 

--- a/tests/unit/test_vectorizer.py
+++ b/tests/unit/test_vectorizer.py
@@ -93,6 +93,9 @@ class TestBaseVectorizerMultiprocessing:
         assert x_single.shape == x_multi.shape  # type: ignore[index]
 
 
+_WORD_CONTEXT_DOCS = ["a b c d e f"] * 200
+
+
 class TestSentToWordContextsMatrix:
     def test_basic(self):
         sents = ["a b c d e"] * 20
@@ -113,3 +116,18 @@ class TestSentToWordContextsMatrix:
         x2, _ = sent_to_word_contexts_matrix(sents, windows=2, min_tf=1, dynamic_weight=True, verbose=False)
         # With dynamic weight, some values should be smaller
         assert x1.sum() >= x2.sum()
+
+    def test_n_workers_equals_single(self):
+        """n_workers=2로 실행해도 어휘와 행렬 합계가 단일 프로세스와 동일하다."""
+        x1, idx1 = sent_to_word_contexts_matrix(_WORD_CONTEXT_DOCS, windows=2, min_tf=1, verbose=False, n_workers=1)
+        x2, idx2 = sent_to_word_contexts_matrix(_WORD_CONTEXT_DOCS, windows=2, min_tf=1, verbose=False, n_workers=2)
+        assert set(idx1) == set(idx2)
+        assert abs(x1.sum() - x2.sum()) < 1e-6  # type: ignore[operator]
+
+    def test_n_workers_lambda_fallback(self):
+        """lambda tokenizer는 pickle 불가이므로 n_workers가 무시되어 정상 동작한다."""
+        sents = ["a b c d e"] * 20
+        x, idx2vocab = sent_to_word_contexts_matrix(
+            sents, windows=2, min_tf=1, tokenizer=lambda x: x.split(), verbose=False, n_workers=2
+        )
+        assert x.shape[0] == x.shape[1]  # type: ignore[index]


### PR DESCRIPTION
## Summary

- `sent_to_word_contexts_matrix()`에 `n_workers` 파라미터 추가
- 어휘 스캔(`_scanning_vocabulary`)과 단어-문맥 추출(`_word_context`) 모두 병렬화
- 기본 tokenizer를 lambda에서 모듈 레벨 `_default_tokenizer` 함수로 교체 (pickle 호환)
- tokenizer가 pickle 불가(lambda 등)인 경우 자동으로 단일 프로세스 폴백 및 로그 출력
- n_workers=2 동등성 검증 테스트 및 lambda fallback 테스트 추가

## Closes

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)