### PR TITLE
feat(hangle): text_to_jamo() 함수 추가

### DIFF
--- a/soynlp/hangle/__init__.py
+++ b/soynlp/hangle/__init__.py
@@ -15,12 +15,14 @@ from .hangle import (
     jongsung_list,
     jungsung_list,
     moum_list,
+    text_to_jamo,
     to_base,
 )
 
 __all__ = [
     "compose",
     "decompose",
+    "text_to_jamo",
     "character_is_korean",
     "character_is_complete_korean",
     "character_is_jaum",

--- a/soynlp/hangle/hangle.py
+++ b/soynlp/hangle/hangle.py
@@ -210,6 +210,52 @@ def character_is_punctuation(c: str) -> bool:
     return i in (33, 34, 39, 44, 46, 63, 96)
 
 
+def text_to_jamo(text: str, join_jongsung: bool = True) -> str:
+    """한국어 텍스트를 자모 단위로 분해한 문자열로 변환한다.
+
+    각 완성형 한글 음절은 (초성, 중성, 종성) 세 자모로 분해된다.
+    종성이 없는 음절은 초성·중성 두 자모로만 구성된다 (기본값).
+    비한글 문자는 그대로 유지된다.
+
+    Args:
+        text: 변환할 텍스트.
+        join_jongsung: True이면 종성이 없을 때 자모를 2개만 출력한다 (기본값).
+            False이면 종성 자리에 공백(' ')을 추가하여 항상 3자모로 출력한다.
+
+    Returns:
+        자모 단위로 분해된 문자열.
+
+    Examples::
+        >>> text_to_jamo("한글")
+        'ㅎㅏㄴㄱㅡㄹ'
+
+        >>> text_to_jamo("나는")
+        'ㄴㅏㄴㅡㄴ'
+
+        >>> text_to_jamo("abc한")
+        'abcㅎㅏㄴ'
+
+        >>> text_to_jamo("가나", join_jongsung=False)
+        'ㄱㅏ ㄴㅏ '
+    """
+    chars: list[str] = []
+    for c in text:
+        result = decompose(c)
+        if result is None:
+            chars.append(c)
+        else:
+            cho, jung, jong = result
+            if cho != " ":
+                chars.append(cho)
+            if jung != " ":
+                chars.append(jung)
+            if jong != " ":
+                chars.append(jong)
+            elif not join_jongsung:
+                chars.append(" ")
+    return "".join(chars)
+
+
 class ConvolutionHangleEncoder:
     """Encode Korean characters into cho/jung/jong one-hot vectors.
 

--- a/tests/unit/test_hangle.py
+++ b/tests/unit/test_hangle.py
@@ -15,6 +15,7 @@ from soynlp.hangle import (
     jaccard_distance,
     jamo_levenshtein,
     levenshtein,
+    text_to_jamo,
     to_base,
 )
 
@@ -142,6 +143,36 @@ class TestJaccardDistance:
 
     def test_empty(self):
         assert jaccard_distance("", "abc") == 1
+
+
+class TestTextToJamo:
+    def test_with_jongsung(self):
+        assert text_to_jamo("한글") == "ㅎㅏㄴㄱㅡㄹ"
+
+    def test_without_jongsung(self):
+        assert text_to_jamo("나는") == "ㄴㅏㄴㅡㄴ"
+
+    def test_non_korean_preserved(self):
+        result = text_to_jamo("abc한")
+        assert result == "abcㅎㅏㄴ"
+
+    def test_space_preserved(self):
+        result = text_to_jamo("한 글")
+        assert " " in result
+
+    def test_join_jongsung_false(self):
+        # 종성 없는 음절은 공백 포함 3자모
+        result = text_to_jamo("가나", join_jongsung=False)
+        assert result == "ㄱㅏ ㄴㅏ "
+
+    def test_mixed_jongsung(self):
+        # '한'(종성ㄴ) + '가'(종성없음) — join_jongsung=False 시 길이 체크
+        result = text_to_jamo("한가", join_jongsung=False)
+        # '한' → ㅎㅏㄴ (3), '가' → ㄱㅏ  (3, 마지막 공백)
+        assert len(result) == 6
+
+    def test_empty(self):
+        assert text_to_jamo("") == ""
 
 
 class TestConvolutionHangleEncoder:


### PR DESCRIPTION
## Summary

- 한국어 텍스트를 자모 단위 문자열로 변환하는 `text_to_jamo()` 함수 추가
- 기존 `decompose()` 활용으로 Compatibility Jamo(ㄱ, ㄴ, ...) 출력 유지
- `join_jongsung=False` 옵션: 종성 없는 음절도 항상 3자모로 출력 (공백 삽입)
- 비한글 문자는 그대로 보존

## Closes

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)