### PR TITLE
feat(noun): check_N_is_NJ 후처리를 postprocessing_nj 파라미터로 제어 가능하게

### DIFF
--- a/soynlp/noun/lr.py
+++ b/soynlp/noun/lr.py
@@ -145,6 +145,7 @@ class LRNounExtractor:
         exclude_syllables: bool = False,
         exclude_numbers: bool = True,
         custom_exclude_function: Callable[[str], bool] | None = None,
+        postprocessing_nj: bool = True,
         n_workers: int = 1,
     ) -> dict[str, NounScore]:
         """Extract nouns from `train_data` or trained L-R graph
@@ -193,6 +194,12 @@ class LRNounExtractor:
                        '아이돌그룹': NounScore(frequency=16, score=1.0),
                        '아이덴티티': NounScore(frequency=25, score=1.0),
                          ... }
+
+            postprocessing_nj (bool) :
+                If True (default), applies the `check_N_is_NJ` postprocessing step which
+                removes `Noun+조사` patterns when the base noun has higher frequency.
+                Set to False to keep `Noun+조사` candidates (e.g., when you need to
+                preserve words like '천불이' alongside '천불').
 
         Returns:
             nouns ({str: NounScore}) : {word: NounScore}
@@ -257,7 +264,7 @@ class LRNounExtractor:
 
         features_to_be_detached = {r for r in self.pos}
         features_to_be_detached.update(self.common)
-        nouns = postprocessing(nouns, lrgraph, features_to_be_detached, min_noun_score, self.verbose)
+        nouns = postprocessing(nouns, lrgraph, features_to_be_detached, min_noun_score, self.verbose, postprocessing_nj)
 
         lrgraph.reset_lrgraph()
         self.nouns = {noun: NounScore(frequency, score) for noun, (frequency, score) in nouns.items()}
@@ -833,6 +840,7 @@ def postprocessing(
     features_to_be_detached: set[str],
     min_noun_score: float,
     verbose: bool,
+    postprocessing_nj: bool = True,
 ) -> dict[str, tuple[int, float]]:
     num_before = len(nouns)
     nouns, removals = detaching_features(nouns, features_to_be_detached)
@@ -842,8 +850,9 @@ def postprocessing(
     nouns, removals = ignore_features(nouns, features_to_be_detached)
     logger.info(f"postprocessing: ignore_features: {num_before} -> {len(nouns)}")
 
-    num_before = len(nouns)
-    nouns, removals = check_N_is_NJ(nouns, lrgraph)
-    logger.info(f"postprocessing: check_N_is_NJ: {num_before} -> {len(nouns)}")
+    if postprocessing_nj:
+        num_before = len(nouns)
+        nouns, removals = check_N_is_NJ(nouns, lrgraph)
+        logger.info(f"postprocessing: check_N_is_NJ: {num_before} -> {len(nouns)}")
 
     return nouns

--- a/soynlp/pipeline/tasks/extract_nouns.py
+++ b/soynlp/pipeline/tasks/extract_nouns.py
@@ -16,6 +16,7 @@ class ExtractNounTaskArgs(TaskArgs):
     extract_compounds: bool = True
     exclude_syllables: bool = False
     exclude_numbers: bool = True
+    postprocessing_nj: bool = True
     verbose: bool = True
     positive_features: str | set | None = None
     negative_features: str | set | None = None
@@ -50,6 +51,7 @@ class ExtractNounTask(Task[ExtractNounTaskArgs]):
             extract_compounds=self._args.extract_compounds,
             exclude_syllables=self._args.exclude_syllables,
             exclude_numbers=self._args.exclude_numbers,
+            postprocessing_nj=self._args.postprocessing_nj,
             n_workers=self._args.n_workers,
         )
 

--- a/tests/unit/test_lrnounextractor.py
+++ b/tests/unit/test_lrnounextractor.py
@@ -1,7 +1,9 @@
 import pytest
 
+from soynlp.core.lrgraph import LRGraph
 from soynlp.noun.lr import (
     check_r_features,
+    postprocessing,
     predict_single_noun,
     remove_ambiguous_features,
 )
@@ -117,3 +119,37 @@ def test_predict_single_noun(word, features, expected_support, expected_score):
     support, score = predict_single_noun(word, features, PREDICT_POS, PREDICT_NEG, PREDICT_COMMON)
     assert support == expected_support
     assert score == expected_score
+
+
+class TestPostprocessingNJ:
+    """postprocessing_nj=False 시 check_N_is_NJ 단계를 건너뜀을 검증한다."""
+
+    def _make_lrgraph(self, eojeols: list[str]) -> LRGraph:
+        lrgraph = LRGraph({})
+        for eojeol in eojeols:
+            lrgraph.add_eojeol(eojeol)
+        return lrgraph
+
+    def test_postprocessing_nj_default_removes(self):
+        """기본값(postprocessing_nj=True)이면 N+조사 패턴이 제거될 수 있다."""
+        # 상식이 vs 상식: '이'가 josaset에 없으면 제거되지 않지만, suffixset에 있으면 제거 안됨
+        # 단순히 postprocessing 함수가 호출될 때 예외 없이 동작하는지 검증
+        nouns: dict[str, tuple[int, float]] = {"상식": (100, 1.0), "상식이": (10, 0.8)}
+        eojeols = ["상식은"] * 100 + ["상식의"] * 50 + ["상식이다"] * 10
+        lrgraph = self._make_lrgraph(eojeols)
+        features: set[str] = set()
+        result = postprocessing(nouns, lrgraph, features, 0.3, False, postprocessing_nj=True)
+        assert isinstance(result, dict)
+
+    def test_postprocessing_nj_false_preserves(self):
+        """postprocessing_nj=False이면 check_N_is_NJ 단계를 건너뛴다."""
+        nouns: dict[str, tuple[int, float]] = {"상식": (100, 1.0), "상식이": (10, 0.8)}
+        eojeols = ["상식은"] * 100 + ["상식의"] * 50
+        lrgraph = self._make_lrgraph(eojeols)
+        features: set[str] = set()
+
+        result_with_nj = postprocessing(nouns.copy(), lrgraph, features, 0.3, False, postprocessing_nj=True)
+        result_without_nj = postprocessing(nouns.copy(), lrgraph, features, 0.3, False, postprocessing_nj=False)
+
+        # postprocessing_nj=False면 check_N_is_NJ가 실행되지 않아 같거나 더 많은 명사를 보존
+        assert len(result_without_nj) >= len(result_with_nj)


### PR DESCRIPTION
## Summary

`Noun + 이` 패턴(`상식이`)을 제거하는 `check_N_is_NJ` 후처리 단계가 경우에 따라 정상 명사(`천불이` 등)도 제거할 수 있어, 이를 선택적으로 비활성화할 수 있도록 수정.

- `LRNounExtractor.extract()`에 `postprocessing_nj: bool = True` 파라미터 추가
- `postprocessing_nj=False` 시 `check_N_is_NJ` 단계를 건너뜀
- `ExtractNounTaskArgs`에도 `postprocessing_nj` 필드 추가 (YAML 파이프라인 설정 지원)
- 단위 테스트 2개 추가

## Closes

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)