### PR TITLE
fix(noun): 경로 구분자를 os.path.join()으로 변경

### DIFF
--- a/soynlp/noun/postprocessing.py
+++ b/soynlp/noun/postprocessing.py
@@ -3,8 +3,8 @@ import os
 from soynlp.core.lrgraph import LRGraph
 
 filepath = os.path.dirname(os.path.realpath(__file__))
-josapath = filepath + "/frequent_enrolled_josa.txt"
-suffixpath = filepath + "/frequent_noun_suffix.txt"
+josapath = os.path.join(filepath, "frequent_enrolled_josa.txt")
+suffixpath = os.path.join(filepath, "frequent_noun_suffix.txt")
 
 
 def load_lines_as_set(path: str) -> set[str]:


### PR DESCRIPTION
## Summary

- `soynlp/noun/postprocessing.py`에서 `filepath + "/..."` 방식의 경로 연결을 `os.path.join()`으로 변경
- Windows 환경에서도 올바르게 동작하는 플랫폼 독립적 경로 처리

## Test plan

- [ ] `uv run pytest` 통과 확인
- [ ] `uv run pre-commit run --all-files` 통과 확인

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)