### PR TITLE
fix(lrgraph): load() 빈 줄 파싱 시 IndexError 방어 처리

### DIFF
--- a/soynlp/core/lrgraph.py
+++ b/soynlp/core/lrgraph.py
@@ -135,6 +135,8 @@ class LRGraph:
             R_freq: dict[str, int] = {}
             for line in file:
                 sep = line.split()
+                if not sep:
+                    continue
                 if not (sep[0] == L):
                     if R_freq:
                         lr_data[L] = R_freq

--- a/tests/unit/test_lrgraph.py
+++ b/tests/unit/test_lrgraph.py
@@ -85,6 +85,20 @@ class TestLRGraph:
             loaded = LRGraph.load(path)
             assert dict(loaded.get_r("이것", topk=-1)) == {"은": 2, "도": 1, "": 3}
 
+    def test_load_tolerates_blank_lines(self):
+        """파일에 빈 줄이 있어도 IndexError 없이 로드된다."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "lrgraph.txt")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("이것 은 2\n")
+                f.write("\n")  # 빈 줄
+                f.write("이것 도 1\n")
+                f.write("   \n")  # 공백만 있는 줄
+            loaded = LRGraph.load(path)
+            r_items = dict(loaded.get_r("이것", topk=-1))
+            assert r_items["은"] == 2
+            assert r_items["도"] == 1
+
     def test_from_sents(self):
         sents = ["이것은 예문 입니다", "이것도 예문 입니다"]
         lrgraph = LRGraph.from_sents(sents)


### PR DESCRIPTION
## Summary

`LRGraph.load()` 메서드에서 파일에 빈 줄이 포함된 경우 `sep = line.split()` 결과가 빈 리스트가 되어 `sep[0]` 접근 시 `IndexError` 발생하는 버그 수정.

```python
# Before — 빈 줄이면 sep == [] → sep[0] IndexError
sep = line.split()
if not (sep[0] == L):

# After — 빈 줄은 skip
sep = line.split()
if not sep:
    continue
if not (sep[0] == L):
```

## Test plan

- [ ] `test_load_tolerates_blank_lines`: 빈 줄/공백 줄이 포함된 파일도 정상 로드됨을 검증

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)