### PR TITLE
refactor(noun): extract() 내 중복 에러 체크 제거

### DIFF
--- a/soynlp/noun/lr.py
+++ b/soynlp/noun/lr.py
@@ -244,8 +244,7 @@ class LRNounExtractor:
                 train_data, min_eojeol_frequency, self.max_l_length, self.max_r_length, self.verbose, n_workers
             )
         else:
-            if self.lrgraph is None:
-                raise ValueError("`train_data` must not be `None` if noun extractor has no LRGraph")
+            assert self.lrgraph is not None  # guaranteed by the check above (is_trained ↔ lrgraph is not None)
             self.lrgraph.reset_lrgraph()
 
         lrgraph = self.lrgraph  # guaranteed non-None after above block
@@ -274,7 +273,14 @@ class LRNounExtractor:
         features_to_be_detached = {r for r in self.pos}
         features_to_be_detached.update(self.common)
         nouns = postprocessing(
-            nouns, lrgraph, features_to_be_detached, min_noun_score, self.verbose, postprocessing_nj, expand_suffixes, min_noun_frequency
+            nouns,
+            lrgraph,
+            features_to_be_detached,
+            min_noun_score,
+            self.verbose,
+            postprocessing_nj,
+            expand_suffixes,
+            min_noun_frequency,
         )
 
         if known_nouns:


### PR DESCRIPTION
## Summary

`LRNounExtractor.extract()` 내에서 동일 조건 `train_data is None && lrgraph is None`을 두 번 체크하는 중복 코드를 제거.

**Before:**
```python
if (not self.is_trained) and (train_data is None):
    raise ValueError(...)  # check 1

if train_data is not None:
    ...
else:
    if self.lrgraph is None:   # check 2 — 항상 False (check 1에서 이미 걸러짐)
        raise ValueError(...)
    self.lrgraph.reset_lrgraph()
```

**After:**
```python
if (not self.is_trained) and (train_data is None):
    raise ValueError(...)

if train_data is not None:
    ...
else:
    assert self.lrgraph is not None  # 정적 타입 분석 지원
    self.lrgraph.reset_lrgraph()
```

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)