### PR TITLE
refactor(noun): postprocessing.py import-time 파일 I/O → lazy loading

### DIFF
--- a/soynlp/noun/postprocessing.py
+++ b/soynlp/noun/postprocessing.py
@@ -1,10 +1,11 @@
+import functools
 import os
 
 from soynlp.core.lrgraph import LRGraph
 
-filepath = os.path.dirname(os.path.realpath(__file__))
-josapath = os.path.join(filepath, "frequent_enrolled_josa.txt")
-suffixpath = os.path.join(filepath, "frequent_noun_suffix.txt")
+_filepath = os.path.dirname(os.path.realpath(__file__))
+_josapath = os.path.join(_filepath, "frequent_enrolled_josa.txt")
+_suffixpath = os.path.join(_filepath, "frequent_noun_suffix.txt")
 
 
 def load_lines_as_set(path: str) -> set[str]:
@@ -12,8 +13,15 @@ def load_lines_as_set(path: str) -> set[str]:
         return {word.strip() for word in f if word.strip()}
 
 
-josaset = load_lines_as_set(josapath)
-suffixset = load_lines_as_set(suffixpath)
+@functools.lru_cache(maxsize=None)
+def _josaset() -> set[str]:
+    return load_lines_as_set(_josapath)
+
+
+@functools.lru_cache(maxsize=None)
+def _suffixset() -> set[str]:
+    return load_lines_as_set(_suffixpath)
+
 
 # 파생 명사 접미사: 생산성 높음/중간
 # 주의: "가"는 josaset에도 포함된 조사이므로 제외 (check_N_is_NJ 후처리와 충돌 가능)
@@ -106,6 +114,8 @@ def expand_suffix_nouns(
 def check_N_is_NJ(
     nouns: dict[str, tuple[int, float]], lrgraph: LRGraph, min_num_of_josa: int = 5
 ) -> tuple[dict[str, tuple[int, float]], set[str]]:
+    josaset = _josaset()
+    suffixset = _suffixset()
     removals: set[str] = set()
     for word, score in nouns.items():
         n = len(word)


### PR DESCRIPTION
## Summary

모듈 import 시 josaset/suffixset 파일을 즉시 읽던 코드를 `functools.lru_cache` 기반 lazy loading으로 전환.

**Before:**
```python
josaset = load_lines_as_set(josapath)   # import 시 실행
suffixset = load_lines_as_set(suffixpath)
```

**After:**
```python
@functools.lru_cache(maxsize=None)
def _josaset() -> set[str]:
    return load_lines_as_set(_josapath)  # 첫 호출 시 실행, 이후 캐시
```

**효과:**
- 경로 오류 시 `ImportError` 대신 런타임 `FileNotFoundError`로 명확한 오류 발생
- 테스트에서 파일 로딩 mock 처리 용이
- 미사용 상태의 import overhead 없음

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)