### PR TITLE
refactor: LRGraph._lr_origin 직접 접근 제거 → public API 도입

### DIFF
--- a/soynlp/core/lrgraph.py
+++ b/soynlp/core/lrgraph.py
@@ -114,6 +114,18 @@ class LRGraph:
             sorted_L_freq = sorted_L_freq[:topk]
         return sorted_L_freq
 
+    def get_total_frequency(self, word: str) -> int:
+        """Return the total corpus frequency of `word` (sum over all R parts in the original graph)."""
+        return sum(self._lr_origin.get(word, {}).values())
+
+    def get_original_r(self, word: str) -> dict[str, int]:
+        """Return the original R-frequency dict for `word` (before any compound extraction edits)."""
+        return dict(self._lr_origin.get(word, {}))
+
+    def iter_original_lr(self):
+        """Yield (L, R_freq_dict) pairs from the original (frozen) L-R graph."""
+        yield from self._lr_origin.items()
+
     def freeze(self) -> None:
         """Freeze current L-R graph state into _lr_origin via deepcopy."""
         self._lr_origin = copy.deepcopy(self._lr)

--- a/soynlp/noun/lr.py
+++ b/soynlp/noun/lr.py
@@ -795,7 +795,7 @@ def extract_compounds_func(
 ) -> tuple[dict[str, tuple[int, float]], dict[str, tuple[str, ...]], MaxScoreTokenizer]:
     candidates = {
         l: rdict.get("", 0)
-        for l, rdict in lrgraph._lr_origin.items()  # noqa: E741
+        for l, rdict in lrgraph.iter_original_lr()  # noqa: E741
         if (len(l) >= 4) and (l not in noun_scores)
     }
     candidates = {l: count for l, count in candidates.items() if count >= min_noun_frequency}  # noqa: E741

--- a/soynlp/noun/postprocessing.py
+++ b/soynlp/noun/postprocessing.py
@@ -89,7 +89,7 @@ def expand_suffix_nouns(
             candidate = noun + suffix
             if candidate in nouns or candidate in added:
                 continue
-            freq = sum(lrgraph._lr_origin.get(candidate, {}).values())
+            freq = lrgraph.get_total_frequency(candidate)
             if freq >= min_noun_frequency:
                 added[candidate] = (freq, 1.0)
         if len(noun) >= 2:
@@ -97,7 +97,7 @@ def expand_suffix_nouns(
                 candidate = noun + suffix
                 if candidate in nouns or candidate in added:
                     continue
-                freq = sum(lrgraph._lr_origin.get(candidate, {}).values())
+                freq = lrgraph.get_total_frequency(candidate)
                 if freq >= min_noun_frequency:
                     added[candidate] = (freq, 1.0)
     return {**nouns, **added}
@@ -120,7 +120,7 @@ def check_N_is_NJ(
                 or score[0] >= nouns[l][0]  # L 의 명사 빈도수가 더 작으면
             ):
                 continue
-            features = lrgraph._lr_origin.get(l, {})
+            features = lrgraph.get_original_r(l)
             features = [r for r in features if r in josaset]
             n_josa = len(features)
             if n_josa >= min_num_of_josa:


### PR DESCRIPTION
## Summary

`_lr_origin` private 속성에 직접 접근하던 패턴을 public 메서드로 캡슐화.

**추가된 메서드:**

| 메서드 | 설명 |
|--------|------|
| `get_total_frequency(word)` | 원본 그래프에서 단어의 총 빈도 반환 |
| `get_original_r(word)` | 원본 R-빈도 dict 반환 (복사본) |
| `iter_original_lr()` | 원본 (L, R_freq) 쌍 이터레이터 |

**변경된 호출처:**
- `noun/postprocessing.py`: `_lr_origin.get(...).values()` → `get_total_frequency()`, `get_original_r()`
- `noun/lr.py`: `_lr_origin.items()` → `iter_original_lr()`

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)