### PR TITLE
style: 에러 메시지 개선 및 일관성 통일

### DIFF
--- a/soynlp/core/lrgraph.py
+++ b/soynlp/core/lrgraph.py
@@ -18,9 +18,9 @@ class LRGraph:
 
     def __init__(self, lrgraph: dict[str, dict[str, int]], max_l_length: int = 10, max_r_length: int = 9):
         if not (isinstance(max_l_length, int) and max_l_length > 1):
-            raise ValueError(f"`max_l_length` must be an integer greater than 1, got {max_l_length}")
+            raise ValueError(f"`max_l_length` must be an integer greater than 1 (typical value is 10), got {max_l_length!r}")
         if not (isinstance(max_r_length, int) and max_r_length > 0):
-            raise ValueError(f"`max_r_length` must be a positive integer, got {max_r_length}")
+            raise ValueError(f"`max_r_length` must be a positive integer (typical value is 9), got {max_r_length!r}")
         self.max_l_length = max_l_length
         self.max_r_length = max_r_length
         self._lr, self._rl = self._to_bidirectional_graph(lrgraph)

--- a/soynlp/noun/lr.py
+++ b/soynlp/noun/lr.py
@@ -307,7 +307,7 @@ class LRNounExtractor:
             $ None
         """
         if self.compound_decomposer is None:
-            raise ValueError("[LRNounExtractor] retrain using `extract(extract_compounds=True)` first")
+            raise ValueError("Compound decomposer is not available. Call `extract(extract_compounds=True)` first.")
         tokens = self.compound_decomposer.tokenize(compound)
         for token in tokens:
             if token not in self.nouns:
@@ -375,7 +375,7 @@ class LRNounExtractor:
         """
         if word_features is None:
             if self.lrgraph is None:
-                raise ValueError("Train LRNounExtractor first")
+                raise ValueError("LRGraph is not available. Call `extract(train_data)` first.")
             word_features = self.lrgraph.get_r(word, -1)
 
         support, score = predict_single_noun(
@@ -413,7 +413,7 @@ class LRNounExtractor:
                 $ ['네이버', '뉴스', '기사', '이용', '학습', '모델', '예시']
         """
         if not self.is_trained or self.nouns is None:
-            raise RuntimeError("Train LRNounExtractor first. LRNounExtractor().extract(train-data)")
+            raise RuntimeError("Noun extractor is not trained. Call `extract(train_data)` first.")
         noun_scores = {noun: score.score for noun, score in self.nouns.items()}
         return NounMatchTokenizer(noun_scores)
 


### PR DESCRIPTION
## Summary

에러 메시지를 사용자가 이해하기 쉽고 해결 방법을 바로 알 수 있게 개선.

| 위치 | Before | After |
|------|--------|-------|
| `lr.py:310` | `[LRNounExtractor] retrain using...` | `Compound decomposer is not available. Call \`extract(extract_compounds=True)\` first.` |
| `lr.py:378` | `Train LRNounExtractor first` | `LRGraph is not available. Call \`extract(train_data)\` first.` |
| `lr.py:416` | `Train LRNounExtractor first. LRNounExtractor()...` | `Noun extractor is not trained. Call \`extract(train_data)\` first.` |
| `lrgraph.py:21` | `must be an integer greater than 1, got X` | `... (typical value is 10), got X` |

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)