### PR TITLE
perf(hangle): list.index() → dict 조회로 O(n) → O(1) 개선

### DIFF
--- a/soynlp/hangle/hangle.py
+++ b/soynlp/hangle/hangle.py
@@ -151,15 +151,19 @@ moum_list = [
     "ㅣ",
 ]
 
+_chosung_to_idx: dict[str, int] = {c: i for i, c in enumerate(chosung_list)}
+_jungsung_to_idx: dict[str, int] = {c: i for i, c in enumerate(jungsung_list)}
+_jongsung_to_idx: dict[str, int] = {c: i for i, c in enumerate(jongsung_list)}
+
 _doublespace_pattern = re.compile(r"\s+")
 
 
 def compose(chosung: str, jungsung: str, jongsung: str) -> str:
     return chr(
         _kor_begin
-        + _chosung_base * chosung_list.index(chosung)
-        + _jungsung_base * jungsung_list.index(jungsung)
-        + jongsung_list.index(jongsung)
+        + _chosung_base * _chosung_to_idx[chosung]
+        + _jungsung_base * _jungsung_to_idx[jungsung]
+        + _jongsung_to_idx[jongsung]
     )
 
 


### PR DESCRIPTION
## Summary

- `compose()` 함수 내 `chosung_list.index()`, `jungsung_list.index()`, `jongsung_list.index()` 호출이 O(n) 선형 탐색
- 모듈 수준에서 `_chosung_to_idx`, `_jungsung_to_idx`, `_jongsung_to_idx` dict 상수를 미리 생성
- `compose()` 에서 dict 조회로 교체 → O(1)

Closes #208

## Test plan

- [ ] `uv run pytest` 전체 통과 확인
- [ ] `compose()` 함수 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)