### PR TITLE
docs: 핵심 내부 함수 docstring 추가

### DIFF
--- a/soynlp/core/lrgraph.py
+++ b/soynlp/core/lrgraph.py
@@ -44,6 +44,20 @@ class LRGraph:
     def from_sents(
         cls, sents: Iterable[str], max_l_length: int = 10, max_r_length: int = 9, verbose: bool = False
     ) -> "LRGraph":
+        """문장 이터러블로부터 LRGraph를 구축한다.
+
+        각 문장을 공백으로 분리하여 어절을 얻고, 어절을 모든 가능한 (L, R) 쌍으로 분해하여
+        빈도를 집계한다. L 길이는 `max_l_length`, R 길이는 `max_r_length`로 제한된다.
+
+        Args:
+            sents: 학습할 문장 이터러블. `Sized`이면 tqdm 진행률 표시에 전체 개수가 사용된다.
+            max_l_length: L 부분의 최대 길이.
+            max_r_length: R 부분의 최대 길이.
+            verbose: True이면 tqdm으로 진행 상황을 출력한다.
+
+        Returns:
+            구축된 LRGraph 인스턴스.
+        """
         if verbose:
             from tqdm import tqdm
 
@@ -64,6 +78,11 @@ class LRGraph:
         return cls(lrgraph_dict, max_l_length, max_r_length)
 
     def reset_lrgraph(self) -> None:
+        """LRGraph를 초기 상태(_lr_origin)로 복원한다.
+
+        명사 추출 과정에서 `remove_lr_pair()` 등으로 수정된 _lr과 _rl을
+        `_lr_origin` 스냅숏으로부터 재구축한다. _lr_origin이 비어 있으면 아무 것도 하지 않는다.
+        """
         if not self._lr_origin:
             return
         self._lr, self._rl = self._to_bidirectional_graph(
@@ -71,6 +90,16 @@ class LRGraph:
         )
 
     def add_lr_pair(self, L: str, R: str, frequency: int = 1) -> None:
+        """(L, R) 쌍의 빈도를 `frequency`만큼 증가시킨다.
+
+        L 또는 R의 길이가 각각 `max_l_length`, `max_r_length`를 초과하면 무시한다.
+        R이 빈 문자열이면 _rl은 갱신하지 않는다.
+
+        Args:
+            L: L 부분 문자열.
+            R: R 부분 문자열 (빈 문자열 허용).
+            frequency: 더할 빈도 값 (기본값 1).
+        """
         if (len(L) > self.max_l_length) or (len(R) > self.max_r_length):
             return
         self._lr.setdefault(L, {})[R] = self._lr.get(L, {}).get(R, 0) + frequency
@@ -106,12 +135,30 @@ class LRGraph:
             self.remove_lr_pair(L, R, frequency)
 
     def get_r(self, L: str, topk: int = 10) -> list[tuple[str, int]]:
+        """주어진 L에 대해 빈도 내림차순으로 (R, frequency) 쌍을 반환한다.
+
+        Args:
+            L: 조회할 L 부분 문자열.
+            topk: 반환할 최대 항목 수. 0 이하이면 전체를 반환한다.
+
+        Returns:
+            [(R, frequency), ...] 형태의 리스트 (빈도 내림차순).
+        """
         sorted_R_freq = sorted(self._lr.get(L, {}).items(), key=lambda R_freq: -R_freq[1])
         if topk > 0:
             sorted_R_freq = sorted_R_freq[:topk]
         return sorted_R_freq
 
     def get_l(self, R: str, topk: int = 10) -> list[tuple[str, int]]:
+        """주어진 R에 대해 빈도 내림차순으로 (L, frequency) 쌍을 반환한다.
+
+        Args:
+            R: 조회할 R 부분 문자열.
+            topk: 반환할 최대 항목 수. 0 이하이면 전체를 반환한다.
+
+        Returns:
+            [(L, frequency), ...] 형태의 리스트 (빈도 내림차순).
+        """
         sorted_L_freq = sorted(self._rl.get(R, {}).items(), key=lambda L_freq: -L_freq[1])
         if topk > 0:
             sorted_L_freq = sorted_L_freq[:topk]

--- a/soynlp/noun/lr.py
+++ b/soynlp/noun/lr.py
@@ -473,6 +473,25 @@ def train_lrgraph(
     verbose: bool,
     n_workers: int = 1,
 ) -> LRGraph:
+    """학습 데이터로부터 LRGraph를 구축하여 반환한다.
+
+    입력 타입에 따라 적절한 변환 경로를 선택한다:
+    - `LRGraph` → 그대로 반환
+    - `EojeolCounter` → `to_lrgraph()`로 변환
+    - `str` (파일 경로) → `CorpusLoader`로 읽은 뒤 `EojeolCounter`를 거쳐 변환
+    - `list[str]` / `CorpusLoader` → `EojeolCounter` 또는 병렬 `corpus_to_lrgraph`로 변환
+
+    Args:
+        train_data: 학습 입력. 파일 경로, 문장 리스트, CorpusLoader, EojeolCounter, LRGraph 중 하나.
+        min_eojeol_frequency: 어절 최소 출현 횟수. 이 값 미만의 어절은 LRGraph에서 제외된다.
+        max_l_length: L 부분의 최대 길이.
+        max_r_length: R 부분의 최대 길이.
+        verbose: True이면 진행 상황을 출력한다.
+        n_workers: 병렬 처리에 사용할 워커 수. 1이면 단일 프로세스로 실행한다.
+
+    Returns:
+        구축된 LRGraph.
+    """
     from soynlp.core import corpus_to_lrgraph
 
     if isinstance(train_data, LRGraph):
@@ -531,6 +550,23 @@ def prepare_noun_candidates(
     exclude_numbers: bool = True,
     custom_exclude_function: Callable[[str], bool] | None = None,
 ) -> set[str]:
+    """LRGraph에서 명사 후보를 추출한다.
+
+    긍정 특징(pos_features, 조사 등)의 왼쪽(L)에 등장한 어절을 명사 후보로 수집한다.
+    각 후보의 긍정 특징 동시출현 빈도 합이 `min_noun_frequency` 이상인 것만 반환한다.
+
+    Args:
+        lrgraph: 구축된 LRGraph.
+        pos_features: 긍정 특징 집합 (조사, 명사 접미사 등).
+        min_noun_frequency: 후보의 최소 출현 빈도.
+        exclude_syllables: True이면 1음절 후보를 제외한다.
+        exclude_numbers: True이면 숫자로만 이루어진 후보를 제외한다.
+        custom_exclude_function: 추가 제외 조건. 단어를 받아 True를 반환하면 제외된다.
+
+    Returns:
+        명사 후보 단어 집합.
+    """
+
     def is_number(word: str) -> bool:
         return number_pattern.sub("", word) == ""
 
@@ -567,16 +603,30 @@ def longer_first_prediction(
     verbose: bool,
     n_workers: int = 1,
 ) -> dict[str, tuple[int, float]]:
-    """Predict noun scores for all candidates in longer-first order.
+    """긴 후보부터 명사 여부를 판별하고 LRGraph를 갱신하며 점수를 반환한다.
 
-    When n_workers > 1, scoring is parallelized using a frozen LRGraph snapshot.
-    The sequential LRGraph modification (removing confirmed noun eojeols) is then
-    applied in a single pass after all scores are gathered.
+    명사로 판정된 단어 L에 대해 `L + R` 형태의 모든 어절을 LRGraph에서 제거한다.
+    이렇게 하면 더 짧은 L의 R 분포에서 긴 명사 형태가 제거되어 정확도가 높아진다.
+    예: '아이디어'가 명사로 판정되면 '아이디'의 R에서 '어'가 제거되어
+    '아이디'도 명사로 판별될 수 있다.
 
-    Trade-off with n_workers > 1: shorter candidates are scored on the original
-    LRGraph without the benefit of longer nouns having been removed first. This
-    may cause minor score differences compared to the sequential (n_workers=1) path.
-    Use n_workers=1 for exact results.
+    n_workers > 1이면 LRGraph 스냅숏을 병렬로 스코어링하므로,
+    순차 방식(n_workers=1)보다 빠르지만 단계적 제거 효과가 없어 점수가 미세하게 달라질 수 있다.
+
+    Args:
+        candidates: 명사 후보 단어 집합.
+        lrgraph: 구축된 LRGraph (순차 모드에서는 인플레이스로 수정된다).
+        pos_features: 긍정 특징 집합.
+        neg_features: 부정 특징 집합.
+        common_features: 긍정·부정 양쪽에 속하는 공통 특징 집합.
+        min_noun_score: 이 값 미만의 점수는 명사로 인정하지 않는다.
+        min_num_of_features: 이 수 미만의 활성 특징이 있으면 명사로 인정하지 않는다.
+        min_eojeol_is_noun_frequency: 어절 단독 출현이 이 수 이상이면 명사로 판정한다.
+        verbose: True이면 진행 상황을 tqdm으로 출력한다.
+        n_workers: 병렬 처리 워커 수. 1이면 순차 실행.
+
+    Returns:
+        {word: (frequency, score)} 형태의 dict.
     """
     sorted_candidates = sorted(candidates, key=lambda x: -len(x))
 

--- a/soynlp/noun/postprocessing.py
+++ b/soynlp/noun/postprocessing.py
@@ -9,6 +9,16 @@ _suffixpath = os.path.join(_filepath, "frequent_noun_suffix.txt")
 
 
 def load_lines_as_set(path: str) -> set[str]:
+    """텍스트 파일을 읽어 줄 단위 문자열 집합으로 반환한다.
+
+    빈 줄과 앞뒤 공백만 있는 줄은 제외된다.
+
+    Args:
+        path: 읽을 파일의 경로.
+
+    Returns:
+        각 줄을 strip한 문자열의 집합.
+    """
     with open(path, encoding="utf-8") as f:
         return {word.strip() for word in f if word.strip()}
 
@@ -49,6 +59,15 @@ _LOW_SUFFIXES: tuple[str, ...] = ("꾼", "쟁이", "질")
 
 
 def subtract(base: dict[str, tuple[int, float]], removals: set[str]) -> dict[str, tuple[int, float]]:
+    """base에서 removals에 포함된 단어를 제외한 새 dict를 반환한다.
+
+    Args:
+        base: 원본 {word: (frequency, score)} dict.
+        removals: 제거할 단어 집합.
+
+    Returns:
+        removals에 없는 단어만 포함하는 새 dict.
+    """
     return {word: score for word, score in base.items() if (word not in removals)}
 
 
@@ -72,6 +91,17 @@ def detaching_features(
 
 
 def ignore_features(nouns: dict[str, tuple[int, float]], features: set[str]) -> tuple[dict[str, tuple[int, float]], set[str]]:
+    """nouns 중 features에 포함된 단어를 제거한다.
+
+    추출된 명사가 조사·어미 등의 특징 집합에 포함될 경우 오추출로 간주하여 제외한다.
+
+    Args:
+        nouns: 현재 추출된 {word: (frequency, score)} dict.
+        features: 제거 대상 특징 집합 (조사, 어미 등).
+
+    Returns:
+        (정제된 nouns dict, 제거된 단어 집합)
+    """
     removals: set[str] = set()
     for word in nouns:
         if word in features:


### PR DESCRIPTION
## Summary

- `noun/lr.py`: `train_lrgraph()`, `prepare_noun_candidates()`, `longer_first_prediction()` docstring 추가
- `noun/postprocessing.py`: `load_lines_as_set()`, `subtract()`, `ignore_features()` docstring 추가
- `core/lrgraph.py`: `from_sents()`, `reset_lrgraph()`, `add_lr_pair()`, `get_r()`, `get_l()` docstring 추가

Closes #209

## Test plan

- [ ] `uv run pytest` 전체 통과 확인
- [ ] docstring 내용이 실제 동작과 일치하는지 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)