### PR TITLE
feat(lrgraph): LRGraph.has_l() / has_r() 편의 메서드 추가

### DIFF
--- a/soynlp/core/lrgraph.py
+++ b/soynlp/core/lrgraph.py
@@ -117,6 +117,14 @@ class LRGraph:
             sorted_L_freq = sorted_L_freq[:topk]
         return sorted_L_freq
 
+    def has_l(self, word: str) -> bool:
+        """주어진 단어가 L 그래프에 존재하는지 반환한다."""
+        return word in self._lr
+
+    def has_r(self, word: str) -> bool:
+        """주어진 단어가 R 그래프에 존재하는지 반환한다."""
+        return word in self._rl
+
     def get_total_frequency(self, word: str) -> int:
         """Return the total corpus frequency of `word` (sum over all R parts in the original graph)."""
         return sum(self._lr_origin.get(word, {}).values())

--- a/tests/unit/test_lrgraph.py
+++ b/tests/unit/test_lrgraph.py
@@ -99,6 +99,16 @@ class TestLRGraph:
             assert r_items["은"] == 2
             assert r_items["도"] == 1
 
+    def test_has_l(self):
+        lrgraph = LRGraph({"이것": {"은": 2}})
+        assert lrgraph.has_l("이것") is True
+        assert lrgraph.has_l("없는단어") is False
+
+    def test_has_r(self):
+        lrgraph = LRGraph({"이것": {"은": 2}})
+        assert lrgraph.has_r("은") is True
+        assert lrgraph.has_r("없는조사") is False
+
     def test_from_sents(self):
         sents = ["이것은 예문 입니다", "이것도 예문 입니다"]
         lrgraph = LRGraph.from_sents(sents)


### PR DESCRIPTION
## Summary

L/R 그래프에 특정 단어 존재 여부를 O(1)로 확인하는 편의 메서드 추가.

- `has_l(word: str) -> bool`: `word in self._lr`
- `has_r(word: str) -> bool`: `word in self._rl`
- 테스트 2개 추가

Closes #214

## Test plan

- [ ] `uv run pytest tests/unit/test_lrgraph.py` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)