### PR TITLE
feat(pipeline): task 반환값 유효성 검사 추가

### DIFF
--- a/soynlp/pipeline/pipeline.py
+++ b/soynlp/pipeline/pipeline.py
@@ -10,7 +10,13 @@ class Pipeline:
         parameters: dict = {}
 
         for task in tasks:
-            parameters |= task(parameters)
+            result = task(parameters)
+            if not isinstance(result, dict):
+                raise TypeError(
+                    f"Task {type(task).__name__!r} returned {type(result).__name__!r}, expected dict. "
+                    "All Task.__call__() implementations must return a dict."
+                )
+            parameters |= result
         return parameters
 
     def _load_tasks(self, config: Config) -> list[Task]:

--- a/tests/unit/pipeline/test_pipeline.py
+++ b/tests/unit/pipeline/test_pipeline.py
@@ -1,11 +1,33 @@
 import os
 import tempfile
 
+import pytest
+
 from soynlp.configs.config import from_dict
 from soynlp.pipeline.pipeline import Pipeline
+from soynlp.pipeline.tasks.task import Task, TaskArgs
+
+
+class _BadTask(Task[TaskArgs]):
+    """Task that returns None instead of dict — for testing only."""
+
+    def __call__(self, parameters: dict) -> dict:  # type: ignore[return]
+        return None  # type: ignore[return-value]
 
 
 class TestPipeline:
+    def test_task_returns_none_raises_type_error(self):
+        from soynlp.pipeline.tasks import TASK_REGISTRY
+
+        TASK_REGISTRY["_Bad"] = _BadTask
+        try:
+            config = from_dict({"pipeline": [{"name": "_Bad", "args": {}}]})
+            pipeline = Pipeline()
+            with pytest.raises(TypeError, match="returned 'NoneType'"):
+                pipeline(config)
+        finally:
+            TASK_REGISTRY.pop("_Bad", None)
+
     def test_dummy_pipeline(self):
         config = from_dict(
             {


### PR DESCRIPTION
## Summary

`task(parameters)` 반환값이 `dict`가 아닐 경우 불명확한 `TypeError` 대신 명확한 오류 메시지를 출력하도록 유효성 검사 추가.

- 기존: `parameters |= None` → `TypeError: unsupported operand type(s) for |=: 'dict' and 'NoneType'`
- 변경: `Task 'XxxTask' returned 'NoneType', expected dict.` 메시지로 원인 명시
- 테스트: `_BadTask`(None 반환) 등록 후 `TypeError` 검증

Closes #215

## Test plan

- [ ] `uv run pytest tests/unit/pipeline/test_pipeline.py` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)