### PR TITLE
feat(postagger): tag() 반환 타입 MorphTag dataclass화

### DIFF
--- a/soynlp/postagger/__init__.py
+++ b/soynlp/postagger/__init__.py
@@ -4,7 +4,7 @@ from .evaluator import BaseEvaluator, LREvaluator, SimpleEojeolEvaluator
 from .lrtagger import LRMaxScoreTagger
 from .maxscore import MaxScoreTagger
 from .pos_extractor import POSExtractor
-from .tagger import BasePostprocessor, BaseTagger, SimpleTagger, UnknownLRPostprocessor
+from .tagger import BasePostprocessor, BaseTagger, MorphTag, SimpleTagger, UnknownLRPostprocessor
 from .template import LR, BaseTemplateMatcher, EojeolTemplateMatcher, LRTemplateMatcher
 
 __all__ = [
@@ -18,6 +18,7 @@ __all__ = [
     "LRTemplateMatcher",
     "LR",
     "BaseTagger",
+    "MorphTag",
     "SimpleTagger",
     "BasePostprocessor",
     "UnknownLRPostprocessor",

--- a/soynlp/postagger/tagger.py
+++ b/soynlp/postagger/tagger.py
@@ -1,5 +1,26 @@
+from dataclasses import dataclass
+
 from .evaluator import BaseEvaluator
 from .template import LR, BaseTemplateMatcher
+
+
+@dataclass(frozen=True, slots=True)
+class MorphTag:
+    """형태소 분석 결과 단위.
+
+    Attributes:
+        surface: 표층형 (실제 텍스트)
+        tag: 품사 태그. 미등록어인 경우 None.
+
+    Example:
+        >>> MorphTag(surface="사과", tag="Noun")
+        MorphTag(surface='사과', tag='Noun')
+        >>> MorphTag(surface="를", tag="Josa")
+        MorphTag(surface='를', tag='Josa')
+    """
+
+    surface: str
+    tag: str | None
 
 
 class BaseTagger:
@@ -16,8 +37,23 @@ class BaseTagger:
 
 
 class SimpleTagger(BaseTagger):
-    def tag(self, sentence: str, flatten: bool = True, debug: bool = False) -> list | tuple[list, list]:
-        sent_: list[list[tuple[str, str | None]]] = []
+    def tag(
+        self, sentence: str, flatten: bool = True, debug: bool = False
+    ) -> list[MorphTag] | list[list[MorphTag]] | tuple[list[MorphTag], list] | tuple[list[list[MorphTag]], list]:
+        """문장을 형태소 분석한다.
+
+        Args:
+            sentence: 분석할 문장.
+            flatten: True이면 모든 어절의 결과를 하나의 리스트로 합쳐 반환.
+                     False이면 어절 단위 리스트의 리스트로 반환.
+            debug: True이면 (결과, 디버그 정보) 튜플로 반환.
+
+        Returns:
+            flatten=True, debug=False: list[MorphTag]
+            flatten=False, debug=False: list[list[MorphTag]]
+            debug=True: 위 결과와 디버그 정보의 tuple
+        """
+        sent_: list[list[MorphTag]] = []
         debug_: list[list] = []
         eojeols = sentence.split()
 
@@ -30,12 +66,12 @@ class SimpleTagger(BaseTagger):
             else:
                 postprocessed = best
 
-            postprocessed_: list[tuple[str, str | None]] = []
+            postprocessed_: list[MorphTag] = []
             for word in postprocessed:
                 if word.l:
-                    postprocessed_.append((word.l, word.l_tag))
+                    postprocessed_.append(MorphTag(word.l, word.l_tag))
                 if word.r:
-                    postprocessed_.append((word.r, word.r_tag))
+                    postprocessed_.append(MorphTag(word.r, word.r_tag))
 
             sent_.append(postprocessed_)
 

--- a/tests/unit/test_postagger.py
+++ b/tests/unit/test_postagger.py
@@ -6,6 +6,7 @@ from soynlp.postagger import (
     LR,
     Dictionary,
     EojeolTemplateMatcher,
+    MorphTag,
     SimpleEojeolEvaluator,
     SimpleTagger,
 )
@@ -103,11 +104,49 @@ class TestSimpleEojeolEvaluator:
         assert best is not None
 
 
+class TestMorphTag:
+    def test_fields(self):
+        mt = MorphTag(surface="사과", tag="Noun")
+        assert mt.surface == "사과"
+        assert mt.tag == "Noun"
+
+    def test_unknown_tag(self):
+        mt = MorphTag(surface="모름", tag=None)
+        assert mt.tag is None
+
+    def test_frozen(self):
+        mt = MorphTag(surface="사과", tag="Noun")
+        with pytest.raises(AttributeError):
+            mt.surface = "바나나"  # type: ignore[misc]
+
+
 class TestSimpleTagger:
-    def test_tag(self, sample_dict):
+    def test_tag_returns_morph_tag_list(self, sample_dict):
         matcher = EojeolTemplateMatcher(sample_dict)
         evaluator = SimpleEojeolEvaluator()
         tagger = SimpleTagger(matcher, evaluator)
         result = tagger.tag("사과")
         assert isinstance(result, list)
         assert len(result) >= 1
+        assert all(isinstance(m, MorphTag) for m in result)
+
+    def test_tag_noun_josa(self, sample_dict):
+        from typing import cast
+
+        matcher = EojeolTemplateMatcher(sample_dict)
+        evaluator = SimpleEojeolEvaluator()
+        tagger = SimpleTagger(matcher, evaluator)
+        result = cast(list[MorphTag], tagger.tag("사과를"))
+        surfaces = [m.surface for m in result]
+        assert "사과" in surfaces or "사과를" in surfaces
+
+    def test_tag_not_flatten(self, sample_dict):
+        from typing import cast
+
+        matcher = EojeolTemplateMatcher(sample_dict)
+        evaluator = SimpleEojeolEvaluator()
+        tagger = SimpleTagger(matcher, evaluator)
+        result = cast(list[list[MorphTag]], tagger.tag("나는 학교에서", flatten=False))
+        assert isinstance(result, list)
+        assert all(isinstance(eojeol, list) for eojeol in result)
+        assert all(isinstance(m, MorphTag) for eojeol in result for m in eojeol)


### PR DESCRIPTION
## 관련 이슈

closes #235

## 변경 내용

`SimpleTagger.tag()`의 반환 타입을 익명 tuple에서 named dataclass로 변경한다.

### 신규: `MorphTag` dataclass

```python
@dataclass(frozen=True, slots=True)
class MorphTag:
    surface: str      # 표층형
    tag: str | None   # 품사 태그 (미등록어면 None)
```

### Before

```python
result = tagger.tag("사과를")
# [("사과", "Noun"), ("를", "Josa")]  — tuple 내부 구조를 알아야 함
```

### After

```python
result = tagger.tag("사과를")
# [MorphTag(surface='사과', tag='Noun'), MorphTag(surface='를', tag='Josa')]
result[0].surface  # '사과'  — IDE 자동완성 및 타입 체크 지원
result[0].tag      # 'Noun'
```

## 테스트

- `TestMorphTag`: dataclass 필드, None tag, frozen 동작 검증
- `TestSimpleTagger`: 반환 타입 MorphTag 검증, flatten=False 동작 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)