### PR TITLE
fix(normalizer): RemoveLongspaceNormalizer 공백 정규화 버그 수정

### DIFF
--- a/soynlp/normalizer/normalizer.py
+++ b/soynlp/normalizer/normalizer.py
@@ -216,11 +216,13 @@ class RepeatCharacterNormalizer(Normalizer):
 
 
 class RemoveLongspaceNormalizer(Normalizer):
+    """2개 이상의 공백(탭·개행 포함)을 단일 공백으로 줄인다."""
+
     def __init__(self):
-        self.pattern = re.compile(r"[ ]{2,}")
+        self.pattern = re.compile(r"\s+")
 
     def normalize(self, s: str) -> str:
-        return self.pattern.sub("  ", s)
+        return self.pattern.sub(" ", s)
 
 
 class PaddingSpacetoWordsNormalizer(Normalizer):

--- a/tests/unit/test_normalizer.py
+++ b/tests/unit/test_normalizer.py
@@ -48,7 +48,10 @@ def test_repeat_character_normalizer():
 
 
 def test_longspace_normalizer():
-    assert RemoveLongspaceNormalizer()("ab     cd    d  f ") == "ab  cd  d  f "
+    assert RemoveLongspaceNormalizer()("ab     cd    d  f ") == "ab cd d f "
+    assert RemoveLongspaceNormalizer()("a\t\tb") == "a b"
+    assert RemoveLongspaceNormalizer()("a\n\nb") == "a b"
+    assert RemoveLongspaceNormalizer()("a b") == "a b"
 
 
 def test_padding_space_to_words():
@@ -74,10 +77,10 @@ def test_normalizer_builder():
     assert normalizer("(주)일이삼 [[공지]]제목 이것은예시다!!") == "(주)일이삼 [[공지]]제목 이것은예시다!!"
 
     normalizer = TextNormalizer.build_normalizer(padding_space=True)
-    assert normalizer("(주)일이삼 [[공지]]제목 이것은예시다!!") == "( 주 ) 일이삼  [[ 공지 ]] 제목  이것은예시다 !!"
+    assert normalizer("(주)일이삼 [[공지]]제목 이것은예시다!!") == "( 주 ) 일이삼 [[ 공지 ]] 제목 이것은예시다 !!"
 
     normalizer = TextNormalizer.build_normalizer(padding_space=True, symbol=False)
-    assert normalizer("(주)일이삼 [[공지]]제목 이것은예시다!!") == " 주  일이삼  공지  제목  이것은예시다 "
+    assert normalizer("(주)일이삼 [[공지]]제목 이것은예시다!!") == " 주 일이삼 공지 제목 이것은예시다 "
 
     normalizer = TextNormalizer.build_normalizer(padding_space=False, symbol=False, custom="/:@.")
     assert (


### PR DESCRIPTION
Closes #229

## 변경 내용

`RemoveLongspaceNormalizer`가 2개 이상의 공백을 두 공백으로 치환하여 실질적인 정규화 효과가 없던 버그를 수정한다.

### 수정 전
```python
self.pattern = re.compile(r"[ ]{2,}")
return self.pattern.sub("  ", s)  # 2+ 공백 → 두 공백 (정규화 안 됨)
```

### 수정 후
```python
self.pattern = re.compile(r"\s+")
return self.pattern.sub(" ", s)   # 모든 연속 공백(탭·개행 포함) → 단일 공백
```

## 테스트

- `test_longspace_normalizer`: 다중 공백, 탭, 개행 케이스 추가
- `test_normalizer_builder`: `padding_space=True` 조합 시 이중 공백이 단일 공백으로 줄어드는 것 반영하여 기대값 갱신