### PR TITLE
refactor(normalizer): emoticon_normalize deprecated 처리 및 HangleEmojiNormalizer로 통합

### DIFF
--- a/soynlp/normalizer/normalizer.py
+++ b/soynlp/normalizer/normalizer.py
@@ -2,12 +2,11 @@ import logging
 import os
 import re
 import unicodedata
+import warnings
 from collections.abc import Callable
 from glob import glob
 
 from tqdm import tqdm
-
-from soynlp.hangle import compose, decompose
 
 logger = logging.getLogger(__name__)
 
@@ -58,42 +57,23 @@ def repeat_normalize(sent: str, num_repeats: int = 2) -> str:
 
 
 def emoticon_normalize(sent: str, num_repeats: int = 2) -> str:
-    if not sent:
-        return sent
+    """한국어 자모-음절 혼합 이모티콘을 정규화한다.
 
-    def _char_type(idx: int) -> int:
-        if 12593 <= idx <= 12622:
-            return 0  # Jaum
-        elif 12623 <= idx <= 12643:
-            return 1  # Moum
-        elif 44032 <= idx <= 55203:
-            return 2  # Complete
-        return -1
+    .. deprecated::
+        `emoticon_normalize`는 deprecated입니다.
+        `HangleEmojiNormalizer`와 `RepeatCharacterNormalizer`를 조합하여 사용하세요.
 
-    idxs = [_char_type(ord(c)) for c in sent]
-    sent_ = []
-    last_idx = len(idxs) - 1
-    for i, (idx, c) in enumerate(zip(idxs, sent)):
-        if (0 < i < last_idx) and (idxs[i - 1] == 0 and idx == 2 and idxs[i + 1] == 1):
-            cho, jung, jong = decompose(c)  # type: ignore[misc]
-            if (cho == sent[i - 1]) and (jung == sent[i + 1]) and (jong == " "):
-                sent_.append(cho)
-                sent_.append(jung)
-            else:
-                sent_.append(c)
-        elif (i < last_idx) and (idx == 2) and (idxs[i + 1] == 0):
-            cho, jung, jong = decompose(c)  # type: ignore[misc]
-            if jong == sent[i + 1]:
-                sent_.append(compose(cho, jung, " "))
-                sent_.append(jong)
-        elif (i > 0) and (idx == 2 and idxs[i - 1] == 0):
-            cho, jung, jong = decompose(c)  # type: ignore[misc]
-            if cho == sent[i - 1]:
-                sent_.append(cho)
-                sent_.append(jung)
-        else:
-            sent_.append(c)
-    return repeat_normalize("".join(sent_), num_repeats)
+        기존 구현은 완성형 음절 뒤에 자음이 오면서 종성 조건이 불일치할 때
+        해당 음절을 묵소 삭제하는 버그가 있었습니다. (예: 'ㅋ크ㅋ' → 'ㅋㅋ')
+        `HangleEmojiNormalizer`는 이 케이스를 올바르게 처리합니다.
+    """
+    warnings.warn(
+        "`emoticon_normalize` is deprecated. Use `HangleEmojiNormalizer` and `RepeatCharacterNormalizer` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    normalized = HangleEmojiNormalizer().normalize(sent)
+    return repeat_normalize(normalized, num_repeats)
 
 
 def only_hangle(sent: str) -> str:

--- a/tests/unit/test_normalizer.py
+++ b/tests/unit/test_normalizer.py
@@ -1,3 +1,5 @@
+import warnings
+
 from soynlp.normalizer.normalizer import (
     HangleEmojiNormalizer,
     PaddingSpacetoWordsNormalizer,
@@ -5,6 +7,7 @@ from soynlp.normalizer.normalizer import (
     RemoveLongspaceNormalizer,
     RepeatCharacterNormalizer,
     TextNormalizer,
+    emoticon_normalize,
     text_normalizer,
 )
 
@@ -87,6 +90,26 @@ def test_normalizer_builder():
         normalizer("soynlp의 주소는 https://github.com/lovit/soynlp/ 입니다.")
         == "soynlp의 주소는 https://github.com/lovit/soynlp/ 입니다."
     )
+
+
+def test_emoticon_normalize_deprecated():
+    """emoticon_normalize는 deprecated이며 HangleEmojiNormalizer와 동일 결과를 반환한다."""
+    s = "어머나 ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ쿠ㅜㅜㅜㅜㅜ이런게 있으면 어떻게 떼어내냐 ㅋㅋㅋㅋㅋ쿠ㅜㅜㅜㅜㅜ 하하"
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = emoticon_normalize(s, num_repeats=2)
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "deprecated" in str(w[0].message).lower()
+
+    expected = RepeatCharacterNormalizer(max_repeat=2)(HangleEmojiNormalizer()(s))
+    assert result == expected
+
+    # 기존 구현의 버그: 'ㅋ크ㅋ' → 'ㅋㅋ' (크가 묵소 삭제됨)
+    # HangleEmojiNormalizer는 이를 올바르게 처리: 'ㅋ크ㅋ' → 'ㅋ크ㅋ' (변경 없음)
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        assert emoticon_normalize("ㅋ크ㅋ", num_repeats=0) == "ㅋ크ㅋ"
 
 
 def test_default_text_normalizer():


### PR DESCRIPTION
Closes #230

## 변경 내용

한국어 자모-음절 혼합 이모티콘 처리 구현이 두 곳에 존재하던 것을 `HangleEmojiNormalizer`로 통합한다.

### `emoticon_normalize()` 버그

기존 `emoticon_normalize()`는 완성형 음절 뒤에 자음이 오면서 종성 불일치 시 해당 음절을 **묵소 삭제**하는 버그가 있었다.

```python
# 버그 재현
emoticon_normalize("ㅋ크ㅋ", num_repeats=0)  # → "ㅋㅋ"  (크가 삭제됨)

# 올바른 동작
HangleEmojiNormalizer().normalize("ㅋ크ㅋ")  # → "ㅋ크ㅋ"  (변경 없음)
```

원인: `elif (i < last_idx) and (idx == 2) and (idxs[i+1] == 0)` 분기에서
`if jong == sent[i+1]` 조건 불충족 시 `else` 절이 없어 문자가 결과에서 누락됨.

### 변경 사항

- `emoticon_normalize()` → `DeprecationWarning` 발생 후 `HangleEmojiNormalizer`로 위임
- `soynlp.hangle.compose/decompose` import 제거 (더 이상 미사용)
- deprecated 동작 및 버그 수정 내용 테스트로 문서화