### PR TITLE
feat(postagger): __repr__ 및 is_trained 추가

### DIFF
--- a/soynlp/postagger/dictionary.py
+++ b/soynlp/postagger/dictionary.py
@@ -15,6 +15,12 @@ class Dictionary:
             else:
                 raise ValueError("dictionary file does not exist")
 
+    def __repr__(self) -> str:
+        num_tags = len(self.pos_dict)
+        num_words = sum(len(words) for words in self.pos_dict.values())
+        tags = list(self.pos_dict.keys())
+        return f"Dictionary(num_tags={num_tags}, num_words={num_words}, tags={tags})"
+
     def _check_max_length(self, pos_dict: dict[str, set[str]]) -> int:
         return max(len(word) for words in pos_dict.values() for word in words)
 

--- a/soynlp/postagger/lrtagger.py
+++ b/soynlp/postagger/lrtagger.py
@@ -102,6 +102,8 @@ class LRMaxScoreTagger:
         self.evaluator = evaluator if evaluator else LREvaluator()
         self.preference = preference if preference else {}
         self.lrgraph = lrgraph if lrgraph else {}
+        self.lrgraph_lmax = lrgraph_lmax
+        self.lrgraph_rmax = lrgraph_rmax
 
         if (not self.lrgraph) and sents:
             self.lrgraph = self._build_lrgraph(sents, lrgraph_lmax, lrgraph_rmax)
@@ -114,6 +116,18 @@ class LRMaxScoreTagger:
                 self.base_tokenizer = MaxScoreTokenizer(scores=self.cohesion_l)
             except Exception as e:
                 logger.warning("MaxScoreTokenizer(cohesion) exception: %s", e)
+
+    @property
+    def is_trained(self) -> bool:
+        """LR 그래프가 구축된 경우 True를 반환한다."""
+        return bool(self.lcount)
+
+    def __repr__(self) -> str:
+        vocab_size = len(self.lcount)
+        return (
+            f"LRMaxScoreTagger(trained={self.is_trained}, vocab_size={vocab_size}, "
+            f"lrgraph_lmax={self.lrgraph_lmax}, lrgraph_rmax={self.lrgraph_rmax})"
+        )
 
     def _build_lrgraph(self, sents, lmax: int = 12, rmax: int = 8) -> dict:
         from collections import Counter, defaultdict
@@ -148,6 +162,8 @@ class LRMaxScoreTagger:
         return lrgraph_norm, lcount, cohesion_l, droprate_l
 
     def pos(self, sent: str, flatten: bool = True, debug: bool = False) -> list:
+        if not self.is_trained:
+            logger.warning("LRMaxScoreTagger has no lrgraph. Results may be inaccurate. Pass sents= or lrgraph= to __init__.")
         sent_ = [self._pos(eojeol, debug) for eojeol in sent.split() if eojeol]
         if flatten:
             sent_ = [word for words in sent_ for word in words]

--- a/soynlp/postagger/pos_extractor.py
+++ b/soynlp/postagger/pos_extractor.py
@@ -25,6 +25,14 @@ class POSExtractor:
         self.verbose = verbose
         self.logpath = logpath
 
+    @property
+    def is_trained(self) -> bool:
+        """extract()가 완료된 경우 True를 반환한다."""
+        return hasattr(self, "noun_extractor") and hasattr(self, "predicator_extractor")
+
+    def __repr__(self) -> str:
+        return f"POSExtractor(trained={self.is_trained}, l_max_length={self.l_max_length}, r_max_length={self.r_max_length})"
+
     def extract(self, sentences):
         self._num_of_eojeols = 0
         self._num_of_covered_eojeols = 0

--- a/soynlp/postagger/tagger.py
+++ b/soynlp/postagger/tagger.py
@@ -32,6 +32,12 @@ class BaseTagger:
         self.dictionary = generator.dictionary
         self.postprocessor = postprocessor
 
+    def __repr__(self) -> str:
+        generator_type = type(self.generator).__name__
+        evaluator_type = type(self.evaluator).__name__
+        postprocessor_type = type(self.postprocessor).__name__ if self.postprocessor else None
+        return f"{type(self).__name__}(generator={generator_type}, evaluator={evaluator_type}, postprocessor={postprocessor_type})"
+
     def tag(self, sentence: str, flatten: bool = True, debug: bool = False) -> list | tuple[list, list]:
         raise NotImplementedError
 

--- a/tests/unit/test_postagger.py
+++ b/tests/unit/test_postagger.py
@@ -7,6 +7,7 @@ from soynlp.postagger import (
     Dictionary,
     EojeolTemplateMatcher,
     MorphTag,
+    POSExtractor,
     SimpleEojeolEvaluator,
     SimpleTagger,
 )
@@ -150,3 +151,31 @@ class TestSimpleTagger:
         assert isinstance(result, list)
         assert all(isinstance(eojeol, list) for eojeol in result)
         assert all(isinstance(m, MorphTag) for eojeol in result for m in eojeol)
+
+    def test_repr(self, sample_dict):
+        matcher = EojeolTemplateMatcher(sample_dict)
+        evaluator = SimpleEojeolEvaluator()
+        tagger = SimpleTagger(matcher, evaluator)
+        r = repr(tagger)
+        assert "SimpleTagger" in r
+        assert "EojeolTemplateMatcher" in r
+
+
+class TestDictionaryRepr:
+    def test_repr(self, sample_dict):
+        r = repr(sample_dict)
+        assert "Dictionary" in r
+        assert "num_tags" in r
+        assert "num_words" in r
+
+
+class TestPOSExtractorRepr:
+    def test_repr_not_trained(self):
+        extractor = POSExtractor()
+        r = repr(extractor)
+        assert "POSExtractor" in r
+        assert "trained=False" in r
+
+    def test_is_trained_initially_false(self):
+        extractor = POSExtractor()
+        assert extractor.is_trained is False


### PR DESCRIPTION
## 관련 이슈

closes #236

## 변경 내용

postagger 주요 클래스에 상태 가시성을 추가한다.

### Dictionary

```python
>>> repr(dictionary)
"Dictionary(num_tags=4, num_words=14, tags=['Noun', 'Verb', 'Josa', 'Adverb'])"
```

### BaseTagger / SimpleTagger

```python
>>> repr(tagger)
"SimpleTagger(generator=EojeolTemplateMatcher, evaluator=SimpleEojeolEvaluator, postprocessor=None)"
```

### LRMaxScoreTagger

```python
>>> tagger = LRMaxScoreTagger()
>>> tagger.is_trained   # False (lrgraph 없음)
>>> repr(tagger)
"LRMaxScoreTagger(trained=False, vocab_size=0, lrgraph_lmax=12, lrgraph_rmax=8)"
>>> tagger.pos("나는")   # 미학습 경고 로그 출력
```

### POSExtractor

```python
>>> extractor = POSExtractor()
>>> extractor.is_trained   # False
>>> repr(extractor)
"POSExtractor(trained=False, l_max_length=10, r_max_length=8)"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)