### PR TITLE
feat(normalizer): EmojiNormalizer 추가 — Unicode 이모지 처리

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
     "tqdm>=4.66",
 ]
 
+[project.optional-dependencies]
+emoji = ["emoji>=2.0"]
+
 [project.scripts]
 soynlp = "soynlp.__main__:main"
 
@@ -23,6 +26,7 @@ dev = [
     "ruff>=0.9.4",
     "pre-commit>=4.1.0",
     "pyright>=1.1.393",
+    "emoji>=2.0",
 ]
 
 [tool.pytest.ini_options]

--- a/soynlp/normalizer/normalizer.py
+++ b/soynlp/normalizer/normalizer.py
@@ -180,6 +180,51 @@ class HangleEmojiNormalizer(Normalizer):
         return "".join(s_)
 
 
+class EmojiNormalizer(Normalizer):
+    """Unicode 이모지를 제거하거나 지정 문자열로 치환한다.
+
+    단일 코드포인트 이모지(😀)뿐 아니라 ZWJ 시퀀스(👨‍💻), Skin tone modifier(👋🏽),
+    Regional indicator(🇰🇷) 등 복합 이모지 시퀀스도 올바르게 처리한다.
+    내부적으로 `emoji` 패키지를 사용하며, 미설치 시 ImportError가 발생한다.
+
+    한국어 자모 이모티콘(ㅋㅋㅋ, ㅎㅎㅎ)은 Unicode 이모지가 아니므로 이 클래스의
+    처리 대상이 아니다. 해당 패턴은 HangleEmojiNormalizer와 RepeatCharacterNormalizer로 처리한다.
+
+    Args:
+        replace (str): 이모지를 치환할 문자열. 기본값 "" (제거).
+            "[EMOJI]"로 설정하면 이모지 위치를 토큰으로 유지할 수 있다.
+
+    Examples:
+        >>> normalizer = EmojiNormalizer()
+        >>> normalizer.normalize("안녕 😀 반가워 🎉")
+        '안녕  반가워 '
+        >>> EmojiNormalizer(replace="[EMOJI]").normalize("안녕 😀")
+        '안녕 [EMOJI]'
+        >>> EmojiNormalizer().normalize("👨‍💻 코딩 중")  # ZWJ 시퀀스
+        ' 코딩 중'
+        >>> EmojiNormalizer().normalize("🇰🇷 한국")  # Regional indicator
+        ' 한국'
+
+    Raises:
+        ImportError: `emoji` 패키지가 설치되지 않은 경우.
+            `pip install soynlp[emoji]` 또는 `pip install emoji` 로 설치.
+    """
+
+    def __init__(self, replace: str = "") -> None:
+        try:
+            import emoji as _emoji_module  # type: ignore[import-untyped]
+
+            self._emoji = _emoji_module
+        except ImportError as e:
+            raise ImportError(
+                "EmojiNormalizer requires the `emoji` package. Install it with: pip install soynlp[emoji]"
+            ) from e
+        self.replace = replace
+
+    def normalize(self, s: str) -> str:
+        return self._emoji.replace_emoji(s, replace=self.replace)
+
+
 class RepeatCharacterNormalizer(Normalizer):
     """
     Args:

--- a/tests/unit/test_normalizer.py
+++ b/tests/unit/test_normalizer.py
@@ -1,6 +1,7 @@
 import warnings
 
 from soynlp.normalizer.normalizer import (
+    EmojiNormalizer,
     HangleEmojiNormalizer,
     PaddingSpacetoWordsNormalizer,
     PassCharacterNormalizer,
@@ -90,6 +91,34 @@ def test_normalizer_builder():
         normalizer("soynlp의 주소는 https://github.com/lovit/soynlp/ 입니다.")
         == "soynlp의 주소는 https://github.com/lovit/soynlp/ 입니다."
     )
+
+
+def test_emoji_normalizer():
+    """EmojiNormalizer는 Unicode 이모지를 제거하거나 치환한다."""
+    n = EmojiNormalizer()
+
+    # 단일 코드포인트 이모지 제거
+    assert n.normalize("안녕 😀 반가워") == "안녕  반가워"
+    assert n.normalize("파티 🎉") == "파티 "
+
+    # replace 옵션으로 토큰 치환
+    n_token = EmojiNormalizer(replace="[EMOJI]")
+    assert n_token.normalize("안녕 😀") == "안녕 [EMOJI]"
+
+    # ZWJ 시퀀스 (👨‍💻 = 👨 + ZWJ + 💻)
+    assert n.normalize("👨‍💻 코딩") == " 코딩"
+
+    # Skin tone modifier (👋🏽 = 👋 + U+1F3FD)
+    assert n.normalize("👋🏽 안녕") == " 안녕"
+
+    # Regional indicator 국기 이모지 (🇰🇷 = 🇰 + 🇷)
+    assert n.normalize("🇰🇷 한국") == " 한국"
+
+    # 이모지가 없으면 원문 유지
+    assert n.normalize("이모지 없음") == "이모지 없음"
+
+    # 한국어 자모 이모티콘은 처리 대상 아님 (HangleEmojiNormalizer 담당)
+    assert n.normalize("ㅋㅋㅋ") == "ㅋㅋㅋ"
 
 
 def test_emoticon_normalize_deprecated():


### PR DESCRIPTION
Closes #231

## 변경 내용

Unicode 이모지를 처리하는 `EmojiNormalizer` 클래스를 추가한다.

### 처리 대상

단순 코드포인트 이모지뿐 아니라 복합 시퀀스도 올바르게 처리한다.

| 종류 | 예시 | 비고 |
|---|---|---|
| 단일 코드포인트 | 😀 🎉 👍 | |
| ZWJ 시퀀스 | 👨‍💻 = 👨 + ZWJ + 💻 | unicodedata만으로는 처리 불가 |
| Skin tone modifier | 👋🏽 = 👋 + U+1F3FD | |
| Regional indicator (국기) | 🇰🇷 = 🇰 + 🇷 | |

### 한국어 자모 이모티콘(ㅋㅋㅋ)과의 관계

ㅋㅋㅋ, ㅎㅎㅎ는 Unicode 이모지가 아닌 한글 자음 반복이다.
`EmojiNormalizer`의 처리 대상이 아니며 기존 `HangleEmojiNormalizer` + `RepeatCharacterNormalizer`가 담당한다.

### optional dependency

```toml
[project.optional-dependencies]
emoji = ["emoji>=2.0"]
```

`emoji` 미설치 상태에서 `EmojiNormalizer()` 생성 시 명확한 `ImportError` 발생:
```
pip install soynlp[emoji]
```