### PR TITLE
feat(postagger): DictionaryProtocol 추상 인터페이스 정의

### DIFF
--- a/soynlp/postagger/__init__.py
+++ b/soynlp/postagger/__init__.py
@@ -1,5 +1,5 @@
 from . import tagset
-from .dictionary import Dictionary
+from .dictionary import Dictionary, DictionaryProtocol
 from .evaluator import BaseEvaluator, LREvaluator, SimpleEojeolEvaluator
 from .lrtagger import LRMaxScoreTagger
 from .maxscore import MaxScoreTagger
@@ -9,6 +9,7 @@ from .template import LR, BaseTemplateMatcher, EojeolTemplateMatcher, LRTemplate
 
 __all__ = [
     "Dictionary",
+    "DictionaryProtocol",
     "BaseEvaluator",
     "SimpleEojeolEvaluator",
     "LREvaluator",

--- a/soynlp/postagger/dictionary.py
+++ b/soynlp/postagger/dictionary.py
@@ -1,5 +1,37 @@
 import json
 import os
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class DictionaryProtocol(Protocol):
+    """커스텀 사전 주입을 위한 인터페이스.
+
+    이 프로토콜을 구현하면 `EojeolTemplateMatcher`, `LRTemplateMatcher` 등에
+    도메인 특화 사전을 주입할 수 있다.
+
+    Example:
+        >>> class MyMedicalDictionary:
+        ...     max_length = 10
+        ...
+        ...     def get_pos(self, word: str) -> list[str]:
+        ...         return ["Noun"] if word in {"암", "세포", "항체"} else []
+        ...
+        ...     def word_is_tag(self, word: str, tag: str) -> bool:
+        ...         return tag == "Noun" and word in {"암", "세포", "항체"}
+        ...
+        >>> matcher = EojeolTemplateMatcher(MyMedicalDictionary())
+    """
+
+    max_length: int
+
+    def get_pos(self, word: str) -> list[str]:
+        """단어의 품사 태그 목록을 반환한다."""
+        ...
+
+    def word_is_tag(self, word: str, tag: str) -> bool:
+        """단어가 주어진 품사 태그에 해당하는지 반환한다."""
+        ...
 
 
 class Dictionary:

--- a/soynlp/postagger/template.py
+++ b/soynlp/postagger/template.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from .dictionary import Dictionary
+from .dictionary import DictionaryProtocol
 
 
 @dataclass(frozen=True, slots=True)
@@ -17,7 +17,7 @@ class LR:
 
 
 class BaseTemplateMatcher:
-    dictionary: Dictionary
+    dictionary: DictionaryProtocol
 
     def generate(self, token: str) -> list[list[LR]]:
         raise NotImplementedError
@@ -26,7 +26,7 @@ class BaseTemplateMatcher:
 class EojeolTemplateMatcher(BaseTemplateMatcher):
     def __init__(
         self,
-        dictionary,
+        dictionary: DictionaryProtocol,
         single_tags: list[str] | None = None,
         lr_templates: list[tuple[str, str]] | None = None,
     ) -> None:
@@ -85,7 +85,7 @@ class EojeolTemplateMatcher(BaseTemplateMatcher):
 class LRTemplateMatcher(BaseTemplateMatcher):
     def __init__(
         self,
-        dictionary,
+        dictionary: DictionaryProtocol,
         ltags: set[str] | None = None,
         templates: dict[str, tuple[str, ...]] | None = None,
     ) -> None:

--- a/tests/unit/test_postagger.py
+++ b/tests/unit/test_postagger.py
@@ -5,6 +5,7 @@ import pytest
 from soynlp.postagger import (
     LR,
     Dictionary,
+    DictionaryProtocol,
     EojeolTemplateMatcher,
     MorphTag,
     POSExtractor,
@@ -179,3 +180,35 @@ class TestPOSExtractorRepr:
     def test_is_trained_initially_false(self):
         extractor = POSExtractor()
         assert extractor.is_trained is False
+
+
+class TestDictionaryProtocol:
+    def test_dictionary_satisfies_protocol(self, sample_dict):
+        assert isinstance(sample_dict, DictionaryProtocol)
+
+    def test_custom_dictionary_satisfies_protocol(self):
+        class MyDict:
+            max_length = 5
+
+            def get_pos(self, word: str) -> list[str]:
+                return ["Noun"] if word == "사과" else []
+
+            def word_is_tag(self, word: str, tag: str) -> bool:
+                return tag == "Noun" and word == "사과"
+
+        my_dict = MyDict()
+        assert isinstance(my_dict, DictionaryProtocol)
+
+    def test_custom_dictionary_usable_in_template(self):
+        class MinimalDict:
+            max_length = 5
+
+            def get_pos(self, word: str) -> list[str]:
+                return ["Noun"] if word in {"사과", "배"} else []
+
+            def word_is_tag(self, word: str, tag: str) -> bool:
+                return tag == "Noun" and word in {"사과", "배"}
+
+        matcher = EojeolTemplateMatcher(MinimalDict())
+        candidates = matcher.generate("사과")
+        assert len(candidates) >= 1


### PR DESCRIPTION
## 관련 이슈

closes #237

## 변경 내용

커스텀 사전 주입을 위한 `DictionaryProtocol`을 정의한다.

### DictionaryProtocol

```python
class DictionaryProtocol(Protocol):
    max_length: int
    def get_pos(self, word: str) -> list[str]: ...
    def word_is_tag(self, word: str, tag: str) -> bool: ...
```

### 커스텀 사전 주입 예시

```python
class MyMedicalDictionary:
    max_length = 10
    def get_pos(self, word: str) -> list[str]:
        return ["Noun"] if word in {"암", "세포"} else []
    def word_is_tag(self, word: str, tag: str) -> bool:
        return tag == "Noun" and word in {"암", "세포"}

matcher = EojeolTemplateMatcher(MyMedicalDictionary())
```

### 변경 범위

- `Dictionary` 구현 클래스는 변경 없음 — 기존 코드 호환성 유지
- `EojeolTemplateMatcher`, `LRTemplateMatcher` 생성자 타입 힌트를 `DictionaryProtocol`로 변경
- `DictionaryProtocol` 공개 export 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)