### PR TITLE
refactor(normalizer): 모듈 수준 deprecated 함수 래퍼 추가 (#232)

### DIFF
--- a/soynlp/normalizer/__init__.py
+++ b/soynlp/normalizer/__init__.py
@@ -1,4 +1,5 @@
 from .normalizer import (
+    EmojiNormalizer,
     HangleEmojiNormalizer,
     PaddingSpacetoWordsNormalizer,
     PassCharacterNormalizer,
@@ -29,6 +30,7 @@ __all__ = [
     "normalize_sent_for_lrgraph",
     "PassCharacterNormalizer",
     "HangleEmojiNormalizer",
+    "EmojiNormalizer",
     "RepeatCharacterNormalizer",
     "RemoveLongspaceNormalizer",
     "PaddingSpacetoWordsNormalizer",

--- a/soynlp/normalizer/normalizer.py
+++ b/soynlp/normalizer/normalizer.py
@@ -31,6 +31,12 @@ def normalize(
     symbol: bool = False,
     remove_repeat: int = 0,
 ) -> str:
+    """.. deprecated:: Use ``TextNormalizer.build_normalizer()`` instead."""
+    warnings.warn(
+        "`normalize` is deprecated. Use `TextNormalizer.build_normalizer()` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     doc = _text_filter.sub(" ", doc)
     if not alphabet:
         doc = _alphabet_pattern.sub(" ", doc)
@@ -46,10 +52,22 @@ def normalize(
 
 
 def remove_doublespace(sent: str) -> str:
+    """.. deprecated:: Use ``RemoveLongspaceNormalizer`` instead."""
+    warnings.warn(
+        "`remove_doublespace` is deprecated. Use `RemoveLongspaceNormalizer` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return _doublespace_pattern.sub(" ", sent)
 
 
 def repeat_normalize(sent: str, num_repeats: int = 2) -> str:
+    """.. deprecated:: Use ``RepeatCharacterNormalizer`` instead."""
+    warnings.warn(
+        "`repeat_normalize` is deprecated. Use `RepeatCharacterNormalizer` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     if num_repeats > 0:
         sent = _repeatchars_pattern.sub("\\1" * num_repeats, sent)
     sent = _doublespace_pattern.sub(" ", sent)
@@ -73,18 +91,39 @@ def emoticon_normalize(sent: str, num_repeats: int = 2) -> str:
         stacklevel=2,
     )
     normalized = HangleEmojiNormalizer().normalize(sent)
-    return repeat_normalize(normalized, num_repeats)
+    if num_repeats > 0:
+        normalized = RepeatCharacterNormalizer(max_repeat=num_repeats).normalize(normalized)
+    normalized = _doublespace_pattern.sub(" ", normalized)
+    return normalized.strip()
 
 
 def only_hangle(sent: str) -> str:
+    """.. deprecated:: Use ``PassCharacterNormalizer(alphabet=False, number=False, symbol=False)`` instead."""
+    warnings.warn(
+        "`only_hangle` is deprecated. Use `PassCharacterNormalizer(alphabet=False, number=False, symbol=False)` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return _doublespace_pattern.sub(" ", _hangle_filter.sub(" ", sent)).strip()
 
 
 def only_hangle_number(sent: str) -> str:
+    """.. deprecated:: Use ``PassCharacterNormalizer(alphabet=False, symbol=False)`` instead."""
+    warnings.warn(
+        "`only_hangle_number` is deprecated. Use `PassCharacterNormalizer(alphabet=False, symbol=False)` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return _doublespace_pattern.sub(" ", _hangle_number_filter.sub(" ", sent)).strip()
 
 
 def only_text(sent: str) -> str:
+    """.. deprecated:: Use ``PassCharacterNormalizer()`` instead."""
+    warnings.warn(
+        "`only_text` is deprecated. Use `PassCharacterNormalizer()` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return _doublespace_pattern.sub(" ", _text_filter.sub(" ", sent)).strip()
 
 

--- a/tests/unit/test_normalizer.py
+++ b/tests/unit/test_normalizer.py
@@ -9,6 +9,12 @@ from soynlp.normalizer.normalizer import (
     RepeatCharacterNormalizer,
     TextNormalizer,
     emoticon_normalize,
+    normalize,
+    only_hangle,
+    only_hangle_number,
+    only_text,
+    remove_doublespace,
+    repeat_normalize,
     text_normalizer,
 )
 
@@ -146,3 +152,55 @@ def test_default_text_normalizer():
         text_normalizer("어머나 ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ쿠ㅜㅜㅜㅜㅜ이런게 있으면 어떻게 떼어내냐 ㅋㅋㅋㅋㅋ쿠ㅜㅜㅜㅜㅜ 하하")
         == "어머나 ㅋㅋㅜㅜ이런게 있으면 어떻게 떼어내냐 ㅋㅋㅜㅜ 하하"
     )
+
+
+def _assert_deprecated(func, *args, **kwargs):
+    """deprecated 함수가 DeprecationWarning을 정확히 1번 발생시키는지 검증한다."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        func(*args, **kwargs)
+        assert len(w) == 1, f"Expected 1 warning, got {len(w)}"
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "deprecated" in str(w[0].message).lower()
+
+
+def test_deprecated_normalize():
+    _assert_deprecated(normalize, "안녕 hello 123")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        assert normalize("안녕 hello 123") == "안녕"
+
+
+def test_deprecated_remove_doublespace():
+    _assert_deprecated(remove_doublespace, "a  b")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        assert remove_doublespace("a  b") == "a b"
+
+
+def test_deprecated_repeat_normalize():
+    _assert_deprecated(repeat_normalize, "ㅋㅋㅋㅋ")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        assert repeat_normalize("ㅋㅋㅋㅋ") == "ㅋㅋ"
+
+
+def test_deprecated_only_hangle():
+    _assert_deprecated(only_hangle, "안녕 hello 123")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        assert only_hangle("안녕 hello 123") == "안녕"
+
+
+def test_deprecated_only_hangle_number():
+    _assert_deprecated(only_hangle_number, "안녕 hello 123")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        assert only_hangle_number("안녕 hello 123") == "안녕 123"
+
+
+def test_deprecated_only_text():
+    _assert_deprecated(only_text, "안녕 hello @@ 123")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        assert only_text("안녕 hello @@ 123") == "안녕 hello 123"


### PR DESCRIPTION
## Summary

- `normalize()`, `remove_doublespace()`, `repeat_normalize()`, `only_hangle()`, `only_hangle_number()`, `only_text()` 에 `DeprecationWarning` 추가
- `emoticon_normalize()`가 `repeat_normalize()`를 호출하여 이중 경고가 발생하는 문제 수정 → `RepeatCharacterNormalizer` 직접 호출로 변경
- `__init__.py`에 `EmojiNormalizer` export 추가
- 6개 deprecated 함수에 대한 경고 발생 테스트 추가 (총 15 tests 통과)

## Test plan

- [x] `uv run pytest tests/unit/test_normalizer.py` — 15 passed
- [x] `uv run pre-commit run --all-files` — all passed

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)