### PR TITLE
feat(pipeline): task_normalize() deprecated 처리 및 NormalizeTask pipeline 분리 (#233)

### DIFF
--- a/examples/normalize/pipeline.yaml
+++ b/examples/normalize/pipeline.yaml
@@ -1,0 +1,18 @@
+pipeline:
+  - name: ReadText
+    args:
+      path: ../../data/91031.txt
+      text_key: text
+  - name: Normalize
+    args:
+      alphabet: true
+      hangle: true
+      number: true
+      symbol: false
+      decompose_hangle_emoji: true
+      remove_repeatchar: 2
+      remove_longspace: true
+  - name: WriteText
+    args:
+      path: normalized.txt
+      text_key: text

--- a/soynlp/normalizer/normalizer.py
+++ b/soynlp/normalizer/normalizer.py
@@ -385,6 +385,12 @@ def task_normalize(
     remove_repeatchar: int = 2,
     remove_longspace: bool = True,
 ):
+    """.. deprecated:: Use ``ReadTextTask`` + ``NormalizeTask`` + ``WriteTextTask`` pipeline 조합을 사용하세요."""
+    warnings.warn(
+        "`task_normalize` is deprecated. Use `ReadTextTask` + `NormalizeTask` + `WriteTextTask` pipeline instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     task_normalizer = TextNormalizer.build_normalizer(
         alphabet=alphabet,
         hangle=hangle,


### PR DESCRIPTION
## Summary

- `task_normalize()` deprecated 처리: `DeprecationWarning` 추가, `ReadTextTask + NormalizeTask + WriteTextTask` 파이프라인 조합 사용 안내
- `examples/normalize/pipeline.yaml`: `NormalizeTask`를 사용하는 예시 파이프라인 추가

`NormalizeTask` 및 `NormalizeTaskArgs`는 `soynlp/pipeline/tasks/normalize.py`에 이미 완전히 구현되어 있으며,
`TASK_REGISTRY`에도 등록되어 있음 (기존 작업 완료 상태)

## Test plan

- [x] `uv run pytest tests/unit/pipeline/tasks/test_normalize.py tests/unit/test_normalizer.py` — 20 passed
- [x] `uv run pre-commit run --all-files` — all passed

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)