### PR TITLE
feat(normalizer): Normalizer 개선 전체 완료 (#227)

### DIFF
--- a/examples/normalize/pipeline.yaml
+++ b/examples/normalize/pipeline.yaml
@@ -1,0 +1,18 @@
+pipeline:
+  - name: ReadText
+    args:
+      path: ../../data/91031.txt
+      text_key: text
+  - name: Normalize
+    args:
+      alphabet: true
+      hangle: true
+      number: true
+      symbol: false
+      decompose_hangle_emoji: true
+      remove_repeatchar: 2
+      remove_longspace: true
+  - name: WriteText
+    args:
+      path: normalized.txt
+      text_key: text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
     "tqdm>=4.66",
 ]
 
+[project.optional-dependencies]
+emoji = ["emoji>=2.0"]
+
 [project.scripts]
 soynlp = "soynlp.__main__:main"
 
@@ -23,6 +26,7 @@ dev = [
     "ruff>=0.9.4",
     "pre-commit>=4.1.0",
     "pyright>=1.1.393",
+    "emoji>=2.0",
 ]
 
 [tool.pytest.ini_options]

--- a/soynlp/normalizer/__init__.py
+++ b/soynlp/normalizer/__init__.py
@@ -1,4 +1,5 @@
 from .normalizer import (
+    EmojiNormalizer,
     HangleEmojiNormalizer,
     PaddingSpacetoWordsNormalizer,
     PassCharacterNormalizer,
@@ -29,6 +30,7 @@ __all__ = [
     "normalize_sent_for_lrgraph",
     "PassCharacterNormalizer",
     "HangleEmojiNormalizer",
+    "EmojiNormalizer",
     "RepeatCharacterNormalizer",
     "RemoveLongspaceNormalizer",
     "PaddingSpacetoWordsNormalizer",

--- a/soynlp/normalizer/normalizer.py
+++ b/soynlp/normalizer/normalizer.py
@@ -180,6 +180,51 @@ class HangleEmojiNormalizer(Normalizer):
         return "".join(s_)
 
 
+class EmojiNormalizer(Normalizer):
+    """Unicode 이모지를 제거하거나 지정 문자열로 치환한다.
+
+    단일 코드포인트 이모지(😀)뿐 아니라 ZWJ 시퀀스(👨‍💻), Skin tone modifier(👋🏽),
+    Regional indicator(🇰🇷) 등 복합 이모지 시퀀스도 올바르게 처리한다.
+    내부적으로 `emoji` 패키지를 사용하며, 미설치 시 ImportError가 발생한다.
+
+    한국어 자모 이모티콘(ㅋㅋㅋ, ㅎㅎㅎ)은 Unicode 이모지가 아니므로 이 클래스의
+    처리 대상이 아니다. 해당 패턴은 HangleEmojiNormalizer와 RepeatCharacterNormalizer로 처리한다.
+
+    Args:
+        replace (str): 이모지를 치환할 문자열. 기본값 "" (제거).
+            "[EMOJI]"로 설정하면 이모지 위치를 토큰으로 유지할 수 있다.
+
+    Examples:
+        >>> normalizer = EmojiNormalizer()
+        >>> normalizer.normalize("안녕 😀 반가워 🎉")
+        '안녕  반가워 '
+        >>> EmojiNormalizer(replace="[EMOJI]").normalize("안녕 😀")
+        '안녕 [EMOJI]'
+        >>> EmojiNormalizer().normalize("👨‍💻 코딩 중")  # ZWJ 시퀀스
+        ' 코딩 중'
+        >>> EmojiNormalizer().normalize("🇰🇷 한국")  # Regional indicator
+        ' 한국'
+
+    Raises:
+        ImportError: `emoji` 패키지가 설치되지 않은 경우.
+            `pip install soynlp[emoji]` 또는 `pip install emoji` 로 설치.
+    """
+
+    def __init__(self, replace: str = "") -> None:
+        try:
+            import emoji as _emoji_module  # type: ignore[import-untyped]
+
+            self._emoji = _emoji_module
+        except ImportError as e:
+            raise ImportError(
+                "EmojiNormalizer requires the `emoji` package. Install it with: pip install soynlp[emoji]"
+            ) from e
+        self.replace = replace
+
+    def normalize(self, s: str) -> str:
+        return self._emoji.replace_emoji(s, replace=self.replace)
+
+
 class RepeatCharacterNormalizer(Normalizer):
     """
     Args:

--- a/soynlp/normalizer/normalizer.py
+++ b/soynlp/normalizer/normalizer.py
@@ -216,11 +216,13 @@ class RepeatCharacterNormalizer(Normalizer):
 
 
 class RemoveLongspaceNormalizer(Normalizer):
+    """2개 이상의 공백(탭·개행 포함)을 단일 공백으로 줄인다."""
+
     def __init__(self):
-        self.pattern = re.compile(r"[ ]{2,}")
+        self.pattern = re.compile(r"\s+")
 
     def normalize(self, s: str) -> str:
-        return self.pattern.sub("  ", s)
+        return self.pattern.sub(" ", s)
 
 
 class PaddingSpacetoWordsNormalizer(Normalizer):

--- a/soynlp/normalizer/normalizer.py
+++ b/soynlp/normalizer/normalizer.py
@@ -385,6 +385,12 @@ def task_normalize(
     remove_repeatchar: int = 2,
     remove_longspace: bool = True,
 ):
+    """.. deprecated:: Use ``ReadTextTask`` + ``NormalizeTask`` + ``WriteTextTask`` pipeline 조합을 사용하세요."""
+    warnings.warn(
+        "`task_normalize` is deprecated. Use `ReadTextTask` + `NormalizeTask` + `WriteTextTask` pipeline instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     task_normalizer = TextNormalizer.build_normalizer(
         alphabet=alphabet,
         hangle=hangle,

--- a/soynlp/normalizer/normalizer.py
+++ b/soynlp/normalizer/normalizer.py
@@ -31,6 +31,12 @@ def normalize(
     symbol: bool = False,
     remove_repeat: int = 0,
 ) -> str:
+    """.. deprecated:: Use ``TextNormalizer.build_normalizer()`` instead."""
+    warnings.warn(
+        "`normalize` is deprecated. Use `TextNormalizer.build_normalizer()` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     doc = _text_filter.sub(" ", doc)
     if not alphabet:
         doc = _alphabet_pattern.sub(" ", doc)
@@ -46,10 +52,22 @@ def normalize(
 
 
 def remove_doublespace(sent: str) -> str:
+    """.. deprecated:: Use ``RemoveLongspaceNormalizer`` instead."""
+    warnings.warn(
+        "`remove_doublespace` is deprecated. Use `RemoveLongspaceNormalizer` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return _doublespace_pattern.sub(" ", sent)
 
 
 def repeat_normalize(sent: str, num_repeats: int = 2) -> str:
+    """.. deprecated:: Use ``RepeatCharacterNormalizer`` instead."""
+    warnings.warn(
+        "`repeat_normalize` is deprecated. Use `RepeatCharacterNormalizer` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     if num_repeats > 0:
         sent = _repeatchars_pattern.sub("\\1" * num_repeats, sent)
     sent = _doublespace_pattern.sub(" ", sent)
@@ -73,18 +91,39 @@ def emoticon_normalize(sent: str, num_repeats: int = 2) -> str:
         stacklevel=2,
     )
     normalized = HangleEmojiNormalizer().normalize(sent)
-    return repeat_normalize(normalized, num_repeats)
+    if num_repeats > 0:
+        normalized = RepeatCharacterNormalizer(max_repeat=num_repeats).normalize(normalized)
+    normalized = _doublespace_pattern.sub(" ", normalized)
+    return normalized.strip()
 
 
 def only_hangle(sent: str) -> str:
+    """.. deprecated:: Use ``PassCharacterNormalizer(alphabet=False, number=False, symbol=False)`` instead."""
+    warnings.warn(
+        "`only_hangle` is deprecated. Use `PassCharacterNormalizer(alphabet=False, number=False, symbol=False)` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return _doublespace_pattern.sub(" ", _hangle_filter.sub(" ", sent)).strip()
 
 
 def only_hangle_number(sent: str) -> str:
+    """.. deprecated:: Use ``PassCharacterNormalizer(alphabet=False, symbol=False)`` instead."""
+    warnings.warn(
+        "`only_hangle_number` is deprecated. Use `PassCharacterNormalizer(alphabet=False, symbol=False)` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return _doublespace_pattern.sub(" ", _hangle_number_filter.sub(" ", sent)).strip()
 
 
 def only_text(sent: str) -> str:
+    """.. deprecated:: Use ``PassCharacterNormalizer()`` instead."""
+    warnings.warn(
+        "`only_text` is deprecated. Use `PassCharacterNormalizer()` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return _doublespace_pattern.sub(" ", _text_filter.sub(" ", sent)).strip()
 
 

--- a/soynlp/normalizer/normalizer.py
+++ b/soynlp/normalizer/normalizer.py
@@ -2,12 +2,11 @@ import logging
 import os
 import re
 import unicodedata
+import warnings
 from collections.abc import Callable
 from glob import glob
 
 from tqdm import tqdm
-
-from soynlp.hangle import compose, decompose
 
 logger = logging.getLogger(__name__)
 
@@ -58,42 +57,23 @@ def repeat_normalize(sent: str, num_repeats: int = 2) -> str:
 
 
 def emoticon_normalize(sent: str, num_repeats: int = 2) -> str:
-    if not sent:
-        return sent
+    """한국어 자모-음절 혼합 이모티콘을 정규화한다.
 
-    def _char_type(idx: int) -> int:
-        if 12593 <= idx <= 12622:
-            return 0  # Jaum
-        elif 12623 <= idx <= 12643:
-            return 1  # Moum
-        elif 44032 <= idx <= 55203:
-            return 2  # Complete
-        return -1
+    .. deprecated::
+        `emoticon_normalize`는 deprecated입니다.
+        `HangleEmojiNormalizer`와 `RepeatCharacterNormalizer`를 조합하여 사용하세요.
 
-    idxs = [_char_type(ord(c)) for c in sent]
-    sent_ = []
-    last_idx = len(idxs) - 1
-    for i, (idx, c) in enumerate(zip(idxs, sent)):
-        if (0 < i < last_idx) and (idxs[i - 1] == 0 and idx == 2 and idxs[i + 1] == 1):
-            cho, jung, jong = decompose(c)  # type: ignore[misc]
-            if (cho == sent[i - 1]) and (jung == sent[i + 1]) and (jong == " "):
-                sent_.append(cho)
-                sent_.append(jung)
-            else:
-                sent_.append(c)
-        elif (i < last_idx) and (idx == 2) and (idxs[i + 1] == 0):
-            cho, jung, jong = decompose(c)  # type: ignore[misc]
-            if jong == sent[i + 1]:
-                sent_.append(compose(cho, jung, " "))
-                sent_.append(jong)
-        elif (i > 0) and (idx == 2 and idxs[i - 1] == 0):
-            cho, jung, jong = decompose(c)  # type: ignore[misc]
-            if cho == sent[i - 1]:
-                sent_.append(cho)
-                sent_.append(jung)
-        else:
-            sent_.append(c)
-    return repeat_normalize("".join(sent_), num_repeats)
+        기존 구현은 완성형 음절 뒤에 자음이 오면서 종성 조건이 불일치할 때
+        해당 음절을 묵소 삭제하는 버그가 있었습니다. (예: 'ㅋ크ㅋ' → 'ㅋㅋ')
+        `HangleEmojiNormalizer`는 이 케이스를 올바르게 처리합니다.
+    """
+    warnings.warn(
+        "`emoticon_normalize` is deprecated. Use `HangleEmojiNormalizer` and `RepeatCharacterNormalizer` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    normalized = HangleEmojiNormalizer().normalize(sent)
+    return repeat_normalize(normalized, num_repeats)
 
 
 def only_hangle(sent: str) -> str:

--- a/soynlp/pipeline/tasks/__init__.py
+++ b/soynlp/pipeline/tasks/__init__.py
@@ -1,7 +1,15 @@
 from soynlp.pipeline.tasks.dummy import DummyTask  # noqa F401
 from soynlp.pipeline.tasks.extract_nouns import ExtractNounTask  # noqa F401
 from soynlp.pipeline.tasks.extract_words import ExtractWordTask  # noqa F401
-from soynlp.pipeline.tasks.normalize import NormalizeTask  # noqa F401
+from soynlp.pipeline.tasks.normalize import (  # noqa F401
+    EmojiNormalizeTask,
+    HangleEmojiNormalizeTask,
+    NormalizeTask,
+    PaddingSpaceNormalizeTask,
+    PassCharacterNormalizeTask,
+    RemoveLongspaceNormalizeTask,
+    RepeatCharacterNormalizeTask,
+)
 from soynlp.pipeline.tasks.read_json import ReadJsonTask  # noqa F401
 from soynlp.pipeline.tasks.read_text import ReadTextTask  # noqa F401
 from soynlp.pipeline.tasks.task import Task  # noqa F401
@@ -17,6 +25,12 @@ __all__ = (
     "ExtractNounTask",
     "ExtractWordTask",
     "NormalizeTask",
+    "PassCharacterNormalizeTask",
+    "HangleEmojiNormalizeTask",
+    "EmojiNormalizeTask",
+    "RepeatCharacterNormalizeTask",
+    "RemoveLongspaceNormalizeTask",
+    "PaddingSpaceNormalizeTask",
     "ReadJsonTask",
     "ReadTextTask",
     "TokenizeTask",
@@ -29,6 +43,12 @@ TASK_REGISTRY: dict[str, type[Task]] = {
     "ExtractNoun": ExtractNounTask,
     "ExtractWord": ExtractWordTask,
     "Normalize": NormalizeTask,
+    "PassCharacterNormalize": PassCharacterNormalizeTask,
+    "HangleEmojiNormalize": HangleEmojiNormalizeTask,
+    "EmojiNormalize": EmojiNormalizeTask,
+    "RepeatCharacterNormalize": RepeatCharacterNormalizeTask,
+    "RemoveLongspaceNormalize": RemoveLongspaceNormalizeTask,
+    "PaddingSpaceNormalize": PaddingSpaceNormalizeTask,
     "ReadJson": ReadJsonTask,
     "ReadText": ReadTextTask,
     "Tokenize": TokenizeTask,

--- a/soynlp/pipeline/tasks/normalize.py
+++ b/soynlp/pipeline/tasks/normalize.py
@@ -1,6 +1,14 @@
 from dataclasses import dataclass
 
-from soynlp.normalizer import TextNormalizer
+from soynlp.normalizer import (
+    EmojiNormalizer,
+    HangleEmojiNormalizer,
+    PaddingSpacetoWordsNormalizer,
+    PassCharacterNormalizer,
+    RemoveLongspaceNormalizer,
+    RepeatCharacterNormalizer,
+    TextNormalizer,
+)
 from soynlp.pipeline.tasks.task import Task, TaskArgs
 
 
@@ -44,3 +52,121 @@ class NormalizeTask(Task[NormalizeTaskArgs]):
 
         parameters[self._args.out_key] = normalized
         return parameters
+
+
+def _apply_normalizer(normalizer, parameters: dict, in_key: str, text_key: str, out_key: str) -> dict:
+    if in_key not in parameters:
+        raise ValueError(f"Not found `{in_key}` in `parameters`")
+    examples = parameters[in_key]
+    normalized = [{**ex, text_key: normalizer(ex[text_key])} for ex in examples]
+    parameters[out_key] = normalized
+    return parameters
+
+
+@dataclass(slots=True)
+class PassCharacterNormalizeTaskArgs(TaskArgs):
+    alphabet: bool = True
+    hangle: bool = True
+    number: bool = True
+    symbol: bool = True
+    custom: str | None = None
+    in_key: str = "corpus"
+    text_key: str = "text"
+    out_key: str = "corpus"
+
+
+class PassCharacterNormalizeTask(Task[PassCharacterNormalizeTaskArgs]):
+    def __call__(self, parameters: dict) -> dict:
+        normalizer = PassCharacterNormalizer(
+            alphabet=self._args.alphabet,
+            hangle=self._args.hangle,
+            number=self._args.number,
+            symbol=self._args.symbol,
+            custom=self._args.custom,
+        )
+        return _apply_normalizer(normalizer, parameters, self._args.in_key, self._args.text_key, self._args.out_key)
+
+
+@dataclass(slots=True)
+class HangleEmojiNormalizeTaskArgs(TaskArgs):
+    in_key: str = "corpus"
+    text_key: str = "text"
+    out_key: str = "corpus"
+
+
+class HangleEmojiNormalizeTask(Task[HangleEmojiNormalizeTaskArgs]):
+    def __call__(self, parameters: dict) -> dict:
+        return _apply_normalizer(
+            HangleEmojiNormalizer(), parameters, self._args.in_key, self._args.text_key, self._args.out_key
+        )
+
+
+@dataclass(slots=True)
+class EmojiNormalizeTaskArgs(TaskArgs):
+    replace: str = ""
+    in_key: str = "corpus"
+    text_key: str = "text"
+    out_key: str = "corpus"
+
+
+class EmojiNormalizeTask(Task[EmojiNormalizeTaskArgs]):
+    def __call__(self, parameters: dict) -> dict:
+        return _apply_normalizer(
+            EmojiNormalizer(replace=self._args.replace),
+            parameters,
+            self._args.in_key,
+            self._args.text_key,
+            self._args.out_key,
+        )
+
+
+@dataclass(slots=True)
+class RepeatCharacterNormalizeTaskArgs(TaskArgs):
+    max_repeat: int = 2
+    in_key: str = "corpus"
+    text_key: str = "text"
+    out_key: str = "corpus"
+
+
+class RepeatCharacterNormalizeTask(Task[RepeatCharacterNormalizeTaskArgs]):
+    def __call__(self, parameters: dict) -> dict:
+        return _apply_normalizer(
+            RepeatCharacterNormalizer(max_repeat=self._args.max_repeat),
+            parameters,
+            self._args.in_key,
+            self._args.text_key,
+            self._args.out_key,
+        )
+
+
+@dataclass(slots=True)
+class RemoveLongspaceNormalizeTaskArgs(TaskArgs):
+    in_key: str = "corpus"
+    text_key: str = "text"
+    out_key: str = "corpus"
+
+
+class RemoveLongspaceNormalizeTask(Task[RemoveLongspaceNormalizeTaskArgs]):
+    def __call__(self, parameters: dict) -> dict:
+        return _apply_normalizer(
+            RemoveLongspaceNormalizer(), parameters, self._args.in_key, self._args.text_key, self._args.out_key
+        )
+
+
+@dataclass(slots=True)
+class PaddingSpaceNormalizeTaskArgs(TaskArgs):
+    custom_character: str | None = None
+    in_key: str = "corpus"
+    text_key: str = "text"
+    out_key: str = "corpus"
+
+
+class PaddingSpaceNormalizeTask(Task[PaddingSpaceNormalizeTaskArgs]):
+    def __call__(self, parameters: dict) -> dict:
+        return _apply_normalizer(
+            PaddingSpacetoWordsNormalizer(custom_character=self._args.custom_character),
+            parameters,
+            self._args.in_key,
+            self._args.text_key,
+            self._args.out_key,
+        )

--- a/tests/unit/pipeline/tasks/test_normalize.py
+++ b/tests/unit/pipeline/tasks/test_normalize.py
@@ -1,6 +1,21 @@
 import pytest
 
-from soynlp.pipeline.tasks.normalize import NormalizeTask, NormalizeTaskArgs
+from soynlp.pipeline.tasks.normalize import (
+    EmojiNormalizeTask,
+    EmojiNormalizeTaskArgs,
+    HangleEmojiNormalizeTask,
+    HangleEmojiNormalizeTaskArgs,
+    NormalizeTask,
+    NormalizeTaskArgs,
+    PaddingSpaceNormalizeTask,
+    PaddingSpaceNormalizeTaskArgs,
+    PassCharacterNormalizeTask,
+    PassCharacterNormalizeTaskArgs,
+    RemoveLongspaceNormalizeTask,
+    RemoveLongspaceNormalizeTaskArgs,
+    RepeatCharacterNormalizeTask,
+    RepeatCharacterNormalizeTaskArgs,
+)
 
 
 class TestNormalizeTask:
@@ -34,3 +49,66 @@ class TestNormalizeTask:
         task = NormalizeTask(NormalizeTaskArgs(remove_repeatchar=2))
         result = task({"corpus": examples})
         assert result["corpus"][0]["text"].count("ㅋ") <= 2
+
+
+class TestPassCharacterNormalizeTask:
+    def test_filter_symbols(self):
+        examples = [{"text": "안녕 hello @@ 123"}]
+        task = PassCharacterNormalizeTask(PassCharacterNormalizeTaskArgs(number=False, symbol=False))
+        result = task({"corpus": examples})
+        assert "@@" not in result["corpus"][0]["text"]
+        assert "123" not in result["corpus"][0]["text"]
+        assert "안녕" in result["corpus"][0]["text"]
+
+    def test_missing_key(self):
+        task = PassCharacterNormalizeTask(PassCharacterNormalizeTaskArgs())
+        with pytest.raises(ValueError, match="Not found"):
+            task({})
+
+
+class TestHangleEmojiNormalizeTask:
+    def test_decompose_emoji(self):
+        examples = [{"text": "ㅋㅋㅋ쿠ㅜㅜ"}]
+        task = HangleEmojiNormalizeTask(HangleEmojiNormalizeTaskArgs())
+        result = task({"corpus": examples})
+        # 분해 결과: 음절 → 자모로 변환되어 길이가 같거나 늘어남
+        assert "쿠" not in result["corpus"][0]["text"] or result["corpus"][0]["text"] == "ㅋㅋㅋ쿠ㅜㅜ"
+
+
+class TestEmojiNormalizeTask:
+    def test_remove_emoji(self):
+        examples = [{"text": "안녕 😀 반가워"}]
+        task = EmojiNormalizeTask(EmojiNormalizeTaskArgs())
+        result = task({"corpus": examples})
+        assert "😀" not in result["corpus"][0]["text"]
+        assert "안녕" in result["corpus"][0]["text"]
+
+    def test_replace_emoji(self):
+        examples = [{"text": "안녕 😀"}]
+        task = EmojiNormalizeTask(EmojiNormalizeTaskArgs(replace="[EMOJI]"))
+        result = task({"corpus": examples})
+        assert "[EMOJI]" in result["corpus"][0]["text"]
+
+
+class TestRepeatCharacterNormalizeTask:
+    def test_reduce_repeats(self):
+        examples = [{"text": "ㅋㅋㅋㅋㅋㅋ"}]
+        task = RepeatCharacterNormalizeTask(RepeatCharacterNormalizeTaskArgs(max_repeat=2))
+        result = task({"corpus": examples})
+        assert result["corpus"][0]["text"].count("ㅋ") == 2
+
+
+class TestRemoveLongspaceNormalizeTask:
+    def test_compress_spaces(self):
+        examples = [{"text": "a     b"}]
+        task = RemoveLongspaceNormalizeTask(RemoveLongspaceNormalizeTaskArgs())
+        result = task({"corpus": examples})
+        assert result["corpus"][0]["text"] == "a b"
+
+
+class TestPaddingSpaceNormalizeTask:
+    def test_pad_words(self):
+        examples = [{"text": "(주)테스트"}]
+        task = PaddingSpaceNormalizeTask(PaddingSpaceNormalizeTaskArgs())
+        result = task({"corpus": examples})
+        assert " 주 " in result["corpus"][0]["text"]

--- a/tests/unit/test_normalizer.py
+++ b/tests/unit/test_normalizer.py
@@ -48,7 +48,10 @@ def test_repeat_character_normalizer():
 
 
 def test_longspace_normalizer():
-    assert RemoveLongspaceNormalizer()("ab     cd    d  f ") == "ab  cd  d  f "
+    assert RemoveLongspaceNormalizer()("ab     cd    d  f ") == "ab cd d f "
+    assert RemoveLongspaceNormalizer()("a\t\tb") == "a b"
+    assert RemoveLongspaceNormalizer()("a\n\nb") == "a b"
+    assert RemoveLongspaceNormalizer()("a b") == "a b"
 
 
 def test_padding_space_to_words():
@@ -74,10 +77,10 @@ def test_normalizer_builder():
     assert normalizer("(주)일이삼 [[공지]]제목 이것은예시다!!") == "(주)일이삼 [[공지]]제목 이것은예시다!!"
 
     normalizer = TextNormalizer.build_normalizer(padding_space=True)
-    assert normalizer("(주)일이삼 [[공지]]제목 이것은예시다!!") == "( 주 ) 일이삼  [[ 공지 ]] 제목  이것은예시다 !!"
+    assert normalizer("(주)일이삼 [[공지]]제목 이것은예시다!!") == "( 주 ) 일이삼 [[ 공지 ]] 제목 이것은예시다 !!"
 
     normalizer = TextNormalizer.build_normalizer(padding_space=True, symbol=False)
-    assert normalizer("(주)일이삼 [[공지]]제목 이것은예시다!!") == " 주  일이삼  공지  제목  이것은예시다 "
+    assert normalizer("(주)일이삼 [[공지]]제목 이것은예시다!!") == " 주 일이삼 공지 제목 이것은예시다 "
 
     normalizer = TextNormalizer.build_normalizer(padding_space=False, symbol=False, custom="/:@.")
     assert (

--- a/tests/unit/test_normalizer.py
+++ b/tests/unit/test_normalizer.py
@@ -9,6 +9,12 @@ from soynlp.normalizer.normalizer import (
     RepeatCharacterNormalizer,
     TextNormalizer,
     emoticon_normalize,
+    normalize,
+    only_hangle,
+    only_hangle_number,
+    only_text,
+    remove_doublespace,
+    repeat_normalize,
     text_normalizer,
 )
 
@@ -146,3 +152,55 @@ def test_default_text_normalizer():
         text_normalizer("어머나 ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ쿠ㅜㅜㅜㅜㅜ이런게 있으면 어떻게 떼어내냐 ㅋㅋㅋㅋㅋ쿠ㅜㅜㅜㅜㅜ 하하")
         == "어머나 ㅋㅋㅜㅜ이런게 있으면 어떻게 떼어내냐 ㅋㅋㅜㅜ 하하"
     )
+
+
+def _assert_deprecated(func, *args, **kwargs):
+    """deprecated 함수가 DeprecationWarning을 정확히 1번 발생시키는지 검증한다."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        func(*args, **kwargs)
+        assert len(w) == 1, f"Expected 1 warning, got {len(w)}"
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "deprecated" in str(w[0].message).lower()
+
+
+def test_deprecated_normalize():
+    _assert_deprecated(normalize, "안녕 hello 123")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        assert normalize("안녕 hello 123") == "안녕"
+
+
+def test_deprecated_remove_doublespace():
+    _assert_deprecated(remove_doublespace, "a  b")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        assert remove_doublespace("a  b") == "a b"
+
+
+def test_deprecated_repeat_normalize():
+    _assert_deprecated(repeat_normalize, "ㅋㅋㅋㅋ")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        assert repeat_normalize("ㅋㅋㅋㅋ") == "ㅋㅋ"
+
+
+def test_deprecated_only_hangle():
+    _assert_deprecated(only_hangle, "안녕 hello 123")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        assert only_hangle("안녕 hello 123") == "안녕"
+
+
+def test_deprecated_only_hangle_number():
+    _assert_deprecated(only_hangle_number, "안녕 hello 123")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        assert only_hangle_number("안녕 hello 123") == "안녕 123"
+
+
+def test_deprecated_only_text():
+    _assert_deprecated(only_text, "안녕 hello @@ 123")
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        assert only_text("안녕 hello @@ 123") == "안녕 hello 123"

--- a/tests/unit/test_normalizer.py
+++ b/tests/unit/test_normalizer.py
@@ -1,3 +1,5 @@
+import warnings
+
 from soynlp.normalizer.normalizer import (
     HangleEmojiNormalizer,
     PaddingSpacetoWordsNormalizer,
@@ -5,6 +7,7 @@ from soynlp.normalizer.normalizer import (
     RemoveLongspaceNormalizer,
     RepeatCharacterNormalizer,
     TextNormalizer,
+    emoticon_normalize,
     text_normalizer,
 )
 
@@ -87,6 +90,26 @@ def test_normalizer_builder():
         normalizer("soynlp의 주소는 https://github.com/lovit/soynlp/ 입니다.")
         == "soynlp의 주소는 https://github.com/lovit/soynlp/ 입니다."
     )
+
+
+def test_emoticon_normalize_deprecated():
+    """emoticon_normalize는 deprecated이며 HangleEmojiNormalizer와 동일 결과를 반환한다."""
+    s = "어머나 ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ쿠ㅜㅜㅜㅜㅜ이런게 있으면 어떻게 떼어내냐 ㅋㅋㅋㅋㅋ쿠ㅜㅜㅜㅜㅜ 하하"
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = emoticon_normalize(s, num_repeats=2)
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "deprecated" in str(w[0].message).lower()
+
+    expected = RepeatCharacterNormalizer(max_repeat=2)(HangleEmojiNormalizer()(s))
+    assert result == expected
+
+    # 기존 구현의 버그: 'ㅋ크ㅋ' → 'ㅋㅋ' (크가 묵소 삭제됨)
+    # HangleEmojiNormalizer는 이를 올바르게 처리: 'ㅋ크ㅋ' → 'ㅋ크ㅋ' (변경 없음)
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        assert emoticon_normalize("ㅋ크ㅋ", num_repeats=0) == "ㅋ크ㅋ"
 
 
 def test_default_text_normalizer():

--- a/tests/unit/test_normalizer.py
+++ b/tests/unit/test_normalizer.py
@@ -1,6 +1,7 @@
 import warnings
 
 from soynlp.normalizer.normalizer import (
+    EmojiNormalizer,
     HangleEmojiNormalizer,
     PaddingSpacetoWordsNormalizer,
     PassCharacterNormalizer,
@@ -90,6 +91,34 @@ def test_normalizer_builder():
         normalizer("soynlp의 주소는 https://github.com/lovit/soynlp/ 입니다.")
         == "soynlp의 주소는 https://github.com/lovit/soynlp/ 입니다."
     )
+
+
+def test_emoji_normalizer():
+    """EmojiNormalizer는 Unicode 이모지를 제거하거나 치환한다."""
+    n = EmojiNormalizer()
+
+    # 단일 코드포인트 이모지 제거
+    assert n.normalize("안녕 😀 반가워") == "안녕  반가워"
+    assert n.normalize("파티 🎉") == "파티 "
+
+    # replace 옵션으로 토큰 치환
+    n_token = EmojiNormalizer(replace="[EMOJI]")
+    assert n_token.normalize("안녕 😀") == "안녕 [EMOJI]"
+
+    # ZWJ 시퀀스 (👨‍💻 = 👨 + ZWJ + 💻)
+    assert n.normalize("👨‍💻 코딩") == " 코딩"
+
+    # Skin tone modifier (👋🏽 = 👋 + U+1F3FD)
+    assert n.normalize("👋🏽 안녕") == " 안녕"
+
+    # Regional indicator 국기 이모지 (🇰🇷 = 🇰 + 🇷)
+    assert n.normalize("🇰🇷 한국") == " 한국"
+
+    # 이모지가 없으면 원문 유지
+    assert n.normalize("이모지 없음") == "이모지 없음"
+
+    # 한국어 자모 이모티콘은 처리 대상 아님 (HangleEmojiNormalizer 담당)
+    assert n.normalize("ㅋㅋㅋ") == "ㅋㅋㅋ"
 
 
 def test_emoticon_normalize_deprecated():


### PR DESCRIPTION
## Summary

이슈 #227 (Normalizer 개선)의 하위 이슈 #229~#234를 모두 완료하고 `refactor-2026-normalizer` 브랜치에서 `refactor-2026`으로 병합.

### 포함된 변경사항

- **#229** — `RemoveLongspaceNormalizer` 버그 수정 (탭·개행 포함 공백 정규화)
- **#230** — `HangleEmojiNormalizer` 개선 (자모-음절 혼합 이모티콘 분해, `emoticon_normalize` deprecated)
- **#231** — `EmojiNormalizer` 신규 추가 (Unicode 이모지 제거/치환, optional `emoji` 패키지)
- **#232** — 모듈 수준 deprecated 함수 래퍼 추가 (`normalize`, `only_hangle` 등 6종)
- **#233** — `task_normalize()` deprecated 처리 및 `NormalizeTask` pipeline 예시 추가
- **#234** — 개별 `XxxNormalize` pipeline Task 6종 추가 (`PassCharacterNormalizeTask` 등)

## Test plan

- [x] 각 PR에서 개별 테스트 통과 확인
- [x] pre-commit 통과

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)