### PR TITLE
fix(lemmatizer): predefined dict 타입 불일치 수정 (#261)

### DIFF
--- a/soynlp/lemmatizer/lemmatizer.py
+++ b/soynlp/lemmatizer/lemmatizer.py
@@ -12,7 +12,7 @@ class Lemmatizer:
         self,
         stems: set[str],
         endings: set[str],
-        predefined: dict | None = None,
+        predefined: dict[tuple[str, str], tuple[tuple[str, str], ...]] | None = None,
     ) -> None:
         self._stems = stems
         self._endings = endings
@@ -21,9 +21,9 @@ class Lemmatizer:
             self._predefined.update(predefined)
 
     def _initialize(self) -> None:
-        self._predefined: dict = {
-            "불어": ("붇다", "불다"),
-            "그래": ("그렇다",),
+        self._predefined: dict[tuple[str, str], tuple[tuple[str, str], ...]] = {
+            ("불", "어"): (("붇", "어"),),  # 붇다 ㄷ 불규칙: 불 + 어 → 붇 + 어
+            ("그", "래"): (("그렇", "아"),),  # 그렇다 ㅎ 불규칙: 그 + 래 split 시 보완
         }
 
     def lemmatize(self, word: str, check_only_stem: bool = False) -> set[tuple[str, str]]:
@@ -50,7 +50,7 @@ class Lemmatizer:
 def lemma_candidate_chat(
     l: str,
     r: str,
-    predefined: dict[tuple[str, str], tuple[str, ...]] | None = None,
+    predefined: dict[tuple[str, str], tuple[tuple[str, str], ...]] | None = None,
     debug: bool = False,
 ) -> set[tuple[str, str]]:
     def character_is_emoticon(c: str) -> bool:
@@ -70,7 +70,7 @@ def lemma_candidate_chat(
 def lemma_candidate(
     l: str,
     r: str,
-    predefined: dict | None = None,
+    predefined: dict[tuple[str, str], tuple[tuple[str, str], ...]] | None = None,
     debug: bool = False,
 ) -> set[tuple[str, str]]:
     def add_lemma(stem: str, ending: str) -> None:
@@ -212,9 +212,9 @@ def lemma_candidate(
 
     # Pre-defined set
     if predefined and (l, r) in predefined:
-        for stem in predefined[(l, r)]:
-            candidates.add(stem)
-            logger.debug("Predefined: %s", stem)
+        for stem_ending in predefined[(l, r)]:
+            candidates.add(stem_ending)
+            logger.debug("Predefined: %s", stem_ending)
 
     # check whether lemma is conjugatable
     candidates_ = set()

--- a/tests/unit/test_lemmatizer.py
+++ b/tests/unit/test_lemmatizer.py
@@ -81,3 +81,44 @@ class TestLemmatizer:
         lem = Lemmatizer(stems=stems, endings=endings)
         result = lem.lemmatize("먹었다", check_only_stem=True)
         assert any(s == "먹" for s, _ in result)
+
+    def test_candidates(self):
+        stems = {"먹", "가"}
+        endings = {"다", "어"}
+        lem = Lemmatizer(stems=stems, endings=endings)
+        result = lem.candidates("먹다")
+        assert isinstance(result, set)
+        assert ("먹", "다") in result
+
+    def test_predefined_merging(self):
+        stems = {"붇", "불"}
+        endings = {"어"}
+        custom = {("살", "아"): (("삶", "아"),)}
+        lem = Lemmatizer(stems=stems, endings=endings, predefined=custom)
+        # custom predefined가 _initialize() 기본값과 합쳐져야 함
+        assert ("살", "아") in lem._predefined
+        assert ("불", "어") in lem._predefined  # 기본값 유지
+
+    def test_predefined_affects_candidates(self):
+        stems = {"붇"}
+        endings = {"어"}
+        lem = Lemmatizer(stems=stems, endings=endings)
+        result = lem.lemmatize("불어")
+        # 붇다 ㄷ불규칙: 불어 → 붇 + 어
+        assert ("붇", "어") in result
+
+
+class TestLemmaCandidatePredefined:
+    def test_predefined_key_is_tuple(self):
+        predefined: dict[tuple[str, str], tuple[tuple[str, str], ...]] = {
+            ("살", "아"): (("삶", "아"),),
+        }
+        result = lemma_candidate("살", "아", predefined=predefined)
+        # predefined 후보가 conjugation 검증을 통과하면 포함됨
+        assert isinstance(result, set)
+        assert all(isinstance(item, tuple) and len(item) == 2 for item in result)
+
+    def test_predefined_type_consistency(self):
+        # predefined 없이도 정상 동작
+        result = lemma_candidate("먹", "었다")
+        assert all(isinstance(item, tuple) for item in result)


### PR DESCRIPTION
## Summary

- `_initialize()`의 `_predefined` dict가 `str` 키를 사용하여 `lemma_candidate()`의 `(l, r)` 튜플 조회에 매칭되지 않는 dead code 버그 수정
- 타입 힌트 명확화: `dict | None` → `dict[tuple[str, str], tuple[tuple[str, str], ...]] | None`
- 테스트 추가: `candidates()`, predefined 머징, predefined 활용, 타입 일관성

## Test plan

- [x] `uv run pytest tests/unit/test_lemmatizer.py -v` — 19 passed
- [x] pre-commit hooks 통과

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)