### PR TITLE
fix(normalizer): normalize() 함수를 PassCharacterNormalizer에 위임하도록 단순화 (#258)

### DIFF
--- a/soynlp/normalizer/normalizer.py
+++ b/soynlp/normalizer/normalizer.py
@@ -12,11 +12,8 @@ logger = logging.getLogger(__name__)
 
 _doublespace_pattern = re.compile(r"\s+")
 _repeatchars_pattern = re.compile(r"(\w)\1{2,}")
-_number_pattern = re.compile(r"[0-9]")
-_punctuation_pattern = re.compile(r"[,.?!]")
 _symbol_pattern = re.compile(r"[()\[\]{}`]")
 _hangle_pattern = re.compile(r"[ㄱ-ㅎㅏ-ㅣ가-힣]")
-_alphabet_pattern = re.compile(r"[a-zA-Z]")
 
 _hangle_filter = re.compile(r"[^ㄱ-ㅎㅏ-ㅣ가-힣]")
 _hangle_number_filter = re.compile(r"[^ㄱ-ㅎㅏ-ㅣ가-힣0-9]")
@@ -31,24 +28,27 @@ def normalize(
     symbol: bool = False,
     remove_repeat: int = 0,
 ) -> str:
-    """.. deprecated:: Use ``TextNormalizer.build_normalizer()`` instead."""
+    """.. deprecated:: Use ``TextNormalizer.build_normalizer()`` instead.
+
+    Note:
+        ``punctuation`` 파라미터는 ``PassCharacterNormalizer``에 직접 대응하는 파라미터가
+        없으므로 ``symbol``로 통합된다. ``PassCharacterNormalizer``로 마이그레이션 시
+        ``symbol=True``를 사용하라.
+    """
     warnings.warn(
         "`normalize` is deprecated. Use `TextNormalizer.build_normalizer()` instead.",
         DeprecationWarning,
         stacklevel=2,
     )
-    doc = _text_filter.sub(" ", doc)
-    if not alphabet:
-        doc = _alphabet_pattern.sub(" ", doc)
-    if not number:
-        doc = _number_pattern.sub(" ", doc)
-    if not punctuation:
-        doc = _punctuation_pattern.sub(" ", doc)
-    if not symbol:
-        doc = _symbol_pattern.sub(" ", doc)
-    if remove_repeat > 0:
-        doc = _repeatchars_pattern.sub("\\1" * remove_repeat, doc)
-    return _doublespace_pattern.sub(" ", doc).strip()
+    return TextNormalizer.build_normalizer(
+        alphabet=alphabet,
+        hangle=True,
+        number=number,
+        symbol=punctuation or symbol,
+        remove_repeatchar=remove_repeat,
+        decompose_hangle_emoji=False,
+        remove_longspace=True,
+    )(doc)
 
 
 def remove_doublespace(sent: str) -> str:


### PR DESCRIPTION
## Summary

- `normalize()` 내부 구현을 `TextNormalizer.build_normalizer()` 위임으로 교체해 `PassCharacterNormalizer`와 일관된 처리 경로를 사용하도록 변경
- `normalize()`에만 사용되던 module-level 패턴 3개 제거 (`_number_pattern`, `_punctuation_pattern`, `_alphabet_pattern`)
- `punctuation` 파라미터는 `symbol`로 통합 (deprecated 함수이므로 동작 변경 허용, docstring에 명시)

## Test plan

- [x] `uv run pytest tests/unit/test_normalizer.py -v` — 15 passed
- [x] pre-commit hooks 통과

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)