### PR TITLE
style(lemmatizer): 로깅 f-string 통일 (#262)

### DIFF
--- a/soynlp/lemmatizer/conjugation.py
+++ b/soynlp/lemmatizer/conjugation.py
@@ -38,7 +38,7 @@ def conjugate_chat(stem: str, ending: str, enforce_moum_harmoney: bool = False, 
         candidates.add(surface)
         if r_first[1] != " ":
             candidates.add(stem + ending)
-        logger.debug("어미의 첫 글자가 자음인 경우: %s", surface)
+        logger.debug(f"어미의 첫 글자가 자음인 경우: {surface}")
 
     return candidates
 
@@ -67,13 +67,13 @@ def conjugate(stem: str, ending: str, enforce_moum_harmoney: bool = False, debug
 
     candidates: set[str] = set()
 
-    logger.debug("l_last = %s", l_last)
-    logger.debug("r_first = %s", r_first)
+    logger.debug(f"l_last = {l_last}")
+    logger.debug(f"r_first = {r_first}")
 
     if ending[0] == "다":
         surface = stem + ending
         candidates.add(surface)
-        logger.debug("'다'로 시작하는 어미: %s", surface)
+        logger.debug(f"'다'로 시작하는 어미: {surface}")
 
     # ㄷ 불규칙 활용: 깨달 + 아 -> 깨달아
     if l_last[2] == "ㄷ" and r_first[0] == "ㅇ":
@@ -81,7 +81,7 @@ def conjugate(stem: str, ending: str, enforce_moum_harmoney: bool = False, debug
         surface = l + ending
         candidates.add(surface)
         candidates.add(stem + ending)  # 받 + 았다 -> 받았다
-        logger.debug("ㄷ 불규칙: %s", surface)
+        logger.debug(f"ㄷ 불규칙: {surface}")
 
     # 르 불규칙 활용: 구르 + 어 -> 굴러
     if (l_last_ == "르" and stem[-2:] != "푸르") and (r_first_ == "아" or r_first_ == "어") and l_len >= 2:
@@ -90,7 +90,7 @@ def conjugate(stem: str, ending: str, enforce_moum_harmoney: bool = False, debug
         r = compose("ㄹ", r_first[1], r_first[2]) + ending[1:]
         surface = l + r
         candidates.add(surface)
-        logger.debug("르 불규칙: %s", surface)
+        logger.debug(f"르 불규칙: {surface}")
 
     # ㅂ 불규칙 활용
     if l_last[2] == "ㅂ":
@@ -109,15 +109,15 @@ def conjugate(stem: str, ending: str, enforce_moum_harmoney: bool = False, debug
             r = compose("ㅇ", c1, r_first[2]) + ending[1:]
             surface = l + r
             candidates.add(surface)
-            logger.debug("ㅂ 불규칙: %s", surface)
+            logger.debug(f"ㅂ 불규칙: {surface}")
             # 워/와 생략 대화체 추가 (간지러워 → 간지러)
             if not ending[1:]:
                 candidates.add(l)
-                logger.debug("ㅂ 불규칙 워/와 생략: %s", l)
+                logger.debug(f"ㅂ 불규칙 워/와 생략: {l}")
         elif r_first[0] == "ㅇ":
             surface = l + ending
             candidates.add(surface)
-            logger.debug("ㅂ 불규칙: %s", surface)
+            logger.debug(f"ㅂ 불규칙: {surface}")
 
     # 어미의 첫글자가 종성일 경우
     if r_first[1] == " " and r_first[0] in ("ㄴ", "ㄹ", "ㅁ", "ㅂ", "ㅆ"):
@@ -127,7 +127,7 @@ def conjugate(stem: str, ending: str, enforce_moum_harmoney: bool = False, debug
         candidates.add(surface)
         if r_first[1] != " ":
             candidates.add(stem + ending)
-        logger.debug("어미의 첫 글자가 -ㄴ, -ㄹ, -ㅁ-, -ㅂ, -ㅆ 인 경우: %s", surface)
+        logger.debug(f"어미의 첫 글자가 -ㄴ, -ㄹ, -ㅁ-, -ㅂ, -ㅆ 인 경우: {surface}")
 
     # ㅅ 불규칙 활용: 붓 + 어 -> 부어
     if (l_last[2] == "ㅅ") and (r_first[0] == "ㅇ"):
@@ -137,7 +137,7 @@ def conjugate(stem: str, ending: str, enforce_moum_harmoney: bool = False, debug
             l = stem[:-1] + compose(l_last[0], l_last[1], " ")
         surface = l + ending
         candidates.add(surface)
-        logger.debug("ㅅ 불규칙: %s", surface)
+        logger.debug(f"ㅅ 불규칙: {surface}")
 
     # 우 불규칙 활용: 푸 + 어 -> 퍼 / 주 + 어 -> 줘
     if l_last[1] == "ㅜ" and l_last[2] == " " and r_first[0] == "ㅇ" and r_first[1] == "ㅓ":
@@ -148,7 +148,7 @@ def conjugate(stem: str, ending: str, enforce_moum_harmoney: bool = False, debug
         r = ending[1:]
         surface = l + r
         candidates.add(surface)
-        logger.debug("우 불규칙: %s", surface)
+        logger.debug(f"우 불규칙: {surface}")
 
     # 오 활용: 오 + 았어 -> 왔어
     if l_last[1] == "ㅗ" and l_last[2] == " " and r_first[0] == "ㅇ" and r_first[1] == "ㅏ":
@@ -156,7 +156,7 @@ def conjugate(stem: str, ending: str, enforce_moum_harmoney: bool = False, debug
         r = ending[1:]
         surface = l + r
         candidates.add(surface)
-        logger.debug("오 활용: %s", surface)
+        logger.debug(f"오 활용: {surface}")
 
     # ㅡ 탈락 불규칙 활용
     if (l_last[1] == "ㅡ") and (l_last[2] == " ") and (r_first[0] == "ㅇ"):
@@ -171,7 +171,7 @@ def conjugate(stem: str, ending: str, enforce_moum_harmoney: bool = False, debug
         if surface is not None:
             candidates.add(surface)
         if surface is not None:
-            logger.debug("ㅡ 탈락 불규칙: %s", surface)
+            logger.debug(f"ㅡ 탈락 불규칙: {surface}")
 
     # 거라, 너라 불규칙 활용
     if ending[:2] == "어라" or ending[:2] == "아라":
@@ -193,14 +193,14 @@ def conjugate(stem: str, ending: str, enforce_moum_harmoney: bool = False, debug
                 r = "아" + ending[1:]
         surface = l + r
         candidates.add(surface)
-        logger.debug("거라/너라 불규칙: %s", surface)
+        logger.debug(f"거라/너라 불규칙: {surface}")
 
     # 러 불규칙 활용: 이르 + 어 -> 이르러
     if (l_last_ == "르" and stem[-2:] != "구르") and (r_first[0] == "ㅇ" and r_first[1] == "ㅓ"):
         r = compose("ㄹ", r_first[1], r_first[2]) + ending[1:]
         surface = stem + r
         candidates.add(surface)
-        logger.debug("러 불규칙: %s", surface)
+        logger.debug(f"러 불규칙: {surface}")
 
     # 여 불규칙 활용
     if l_last_ == "하" and r_first[0] == "ㅇ" and (r_first[1] == "ㅏ" or r_first[1] == "ㅓ"):
@@ -211,7 +211,7 @@ def conjugate(stem: str, ending: str, enforce_moum_harmoney: bool = False, debug
         r = ending[1:]
         surface1 = l + r
         candidates.add(surface1)
-        logger.debug("여 불규칙: %s, %s", surface0, surface1)
+        logger.debug(f"여 불규칙: {surface0}, {surface1}")
 
     # ㅎ (탈락) 불규칙 활용
     if l_last[2] == "ㅎ" and r_first[1] != " ":
@@ -222,7 +222,7 @@ def conjugate(stem: str, ending: str, enforce_moum_harmoney: bool = False, debug
         r = ending
         surface = l + r
         candidates.add(surface)
-        logger.debug("ㅎ 탈락 불규칙: %s", surface)
+        logger.debug(f"ㅎ 탈락 불규칙: {surface}")
 
     # ㅎ (축약) 불규칙 활용
     if (l_last[2] == "ㅎ" and l_last_ != "좋") and (r_first[0] == "ㅇ" and (r_first[1] == "ㅏ" or r_first[1] == "ㅓ")):
@@ -230,13 +230,13 @@ def conjugate(stem: str, ending: str, enforce_moum_harmoney: bool = False, debug
         r = ending[1:]
         surface = l + r
         candidates.add(surface)
-        logger.debug("ㅎ 축약 불규칙: %s", surface)
+        logger.debug(f"ㅎ 축약 불규칙: {surface}")
 
     # ㅎ + 네 불규칙 활용
     if l_last[2] == "ㅎ" and r_first[0] == "ㄴ" and r_first[1] != " ":
         surface = stem + ending
         candidates.add(surface)
-        logger.debug("ㅎ + 네 불규칙: %s", surface)
+        logger.debug(f"ㅎ + 네 불규칙: {surface}")
 
     # 이 + 어 -> 여 규칙활용
     if r_first_ == "어" and l_last[1] == "ㅣ" and l_last[2] == " ":
@@ -244,7 +244,7 @@ def conjugate(stem: str, ending: str, enforce_moum_harmoney: bool = False, debug
         candidates.add(surface)
         surface = stem + ending
         candidates.add(surface)
-        logger.debug("이 + 어 -> 여 규칙: %s", surface)
+        logger.debug(f"이 + 어 -> 여 규칙: {surface}")
 
     if not candidates and r_first[1] != " ":
         if (l_last[2] == " ") and (r_first[0] == "ㅇ") and (r_first[1] == l_last[1]):
@@ -255,7 +255,7 @@ def conjugate(stem: str, ending: str, enforce_moum_harmoney: bool = False, debug
         else:
             surface = stem + ending
             candidates.add(surface)
-        logger.debug("L + R 규칙 결합: %s", surface)
+        logger.debug(f"L + R 규칙 결합: {surface}")
 
     return candidates
 

--- a/soynlp/lemmatizer/lemmatizer.py
+++ b/soynlp/lemmatizer/lemmatizer.py
@@ -61,7 +61,7 @@ def lemma_candidate_chat(
 
     if not r and character_is_emoticon(l_last[2]):
         l_ = l[:-1] + compose(l_last[0], l_last[1], " ")
-        logger.debug("마지막 종성이 이모티콘으로 의심되는 경우: %s + ()", l_)
+        logger.debug(f"마지막 종성이 이모티콘으로 의심되는 경우: {l_} + ()")
         candidates.update(lemma_candidate(l_, r, predefined, debug))
 
     return candidates
@@ -77,7 +77,7 @@ def lemma_candidate(
         candidates.add((stem, ending))
 
     def debug_message(message: str, left: str, right: str) -> None:
-        logger.debug("%s: %s + %s", message, left, right)
+        logger.debug(f"{message}: {left} + {right}")
 
     candidates: set[tuple[str, str]] = {(l, r)}
     word = l + r
@@ -223,7 +223,7 @@ def lemma_candidate(
     if predefined and (l, r) in predefined:
         for stem_ending in predefined[(l, r)]:
             candidates.add(stem_ending)
-            logger.debug("Predefined: %s", stem_ending)
+            logger.debug(f"Predefined: {stem_ending}")
 
     # check whether lemma is conjugatable
     candidates_ = set()


### PR DESCRIPTION
## Summary

`conjugation.py`(22곳), `lemmatizer.py`(7곳)의 `%` formatting 로깅을 f-string으로 통일한다.

## Test plan

- [x] `uv run pytest tests/unit/test_lemmatizer.py -q` — 14 passed
- [x] pre-commit hooks 통과

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)