### PR TITLE
refactor(normalizer): TextNormalizer를 Normalizer 상속에서 분리 (#257)

### DIFF
--- a/soynlp/normalizer/normalizer.py
+++ b/soynlp/normalizer/normalizer.py
@@ -3,6 +3,7 @@ import os
 import re
 import unicodedata
 import warnings
+from abc import ABC, abstractmethod
 from collections.abc import Callable
 from glob import glob
 
@@ -145,12 +146,14 @@ def normalize_sent_for_lrgraph(sent: str) -> str:
     return " ".join(sent_)
 
 
-class Normalizer:
+class Normalizer(ABC):
+    """단일 정규화 규칙을 구현하는 추상 기반 클래스."""
+
     def __call__(self, s: str) -> str:
         return self.normalize(s)
 
-    def normalize(self, s: str) -> str:
-        raise NotImplementedError("Implement `normalize` function")
+    @abstractmethod
+    def normalize(self, s: str) -> str: ...
 
 
 class PassCharacterNormalizer(Normalizer):
@@ -308,14 +311,24 @@ class PaddingSpacetoWordsNormalizer(Normalizer):
         return "".join(s_)
 
 
-class TextNormalizer(Normalizer):
-    def __init__(self, normalizer_list):
+class TextNormalizer:
+    """여러 Normalizer를 순차 적용하는 컴포지트 클래스.
+
+    단일 정규화 규칙을 구현하는 ``Normalizer``와 달리, ``TextNormalizer``는
+    여러 normalizer를 조합하여 파이프라인을 구성한다. ``Normalizer``를 상속하지
+    않으며, ``normalize(s) -> str`` 인터페이스를 duck-typing으로 충족한다.
+    """
+
+    def __init__(self, normalizer_list: list[Callable[[str], str]]) -> None:
         if not isinstance(normalizer_list, list):
             raise ValueError("Available only `list` as `normalizer_list`")
         for i, module in enumerate(normalizer_list):
             if not callable(module):
                 raise ValueError(f"{i}th module is not callable")
         self.modules = normalizer_list
+
+    def __call__(self, s: str) -> str:
+        return self.normalize(s)
 
     def normalize(self, s: str) -> str:
         for module in self.modules:


### PR DESCRIPTION
## Summary

- `Normalizer` 클래스를 `ABC`로 전환하고 `normalize()`를 `@abstractmethod`로 명시
- `TextNormalizer`에서 `Normalizer` 상속 제거 — 여러 normalizer를 조합하는 컴포지트 패턴임을 클래스 계층으로 명확히 표현
  - `__call__`, `normalize` 메서드를 직접 구현
  - `normalizer_list` 타입 힌트 `list[Callable[[str], str]]`으로 명시화

## Background

`TextNormalizer`는 개별 정규화 규칙을 구현하는 `Normalizer`가 아니라, 여러 normalizer를 순차 적용하는 컴포지트이다. 이를 `Normalizer`로부터 분리하여 의미적 명확성을 높인다.

Closes #257

## Test plan

- [x] `uv run pytest tests/unit/test_normalizer.py` — 17 passed
- [x] `uv run pre-commit run --all-files` — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)