### PR TITLE
feat(normalizer): JamoNormalizer 추가 — 자모 시퀀스를 음절로 재조합 (#260)

### DIFF
--- a/soynlp/normalizer/__init__.py
+++ b/soynlp/normalizer/__init__.py
@@ -1,6 +1,7 @@
 from .normalizer import (
     EmojiNormalizer,
     HangleEmojiNormalizer,
+    JamoNormalizer,
     PaddingSpacetoWordsNormalizer,
     PassCharacterNormalizer,
     RemoveLongspaceNormalizer,
@@ -28,6 +29,7 @@ __all__ = [
     "only_text",
     "remain_hangle_on_last",
     "normalize_sent_for_lrgraph",
+    "JamoNormalizer",
     "PassCharacterNormalizer",
     "HangleEmojiNormalizer",
     "EmojiNormalizer",

--- a/soynlp/normalizer/normalizer.py
+++ b/soynlp/normalizer/normalizer.py
@@ -9,6 +9,8 @@ from glob import glob
 
 from tqdm import tqdm
 
+from soynlp.hangle import chosung_list, compose, jongsung_list, jungsung_list
+
 logger = logging.getLogger(__name__)
 
 _doublespace_pattern = re.compile(r"\s+")
@@ -154,6 +156,48 @@ class Normalizer(ABC):
 
     @abstractmethod
     def normalize(self, s: str) -> str: ...
+
+
+class JamoNormalizer(Normalizer):
+    """연속된 자모 문자 시퀀스를 음절로 재조합하는 정규화기.
+
+    인터넷 대화체에서 욕설 등을 자소 분리로 표기하는 경우를 처리한다.
+    예: ㅆㅡㄹㅐㄱㅣ → 쓰래기, ㅆㅣㅂㅏㄹ → 씨발
+
+    완성형 한글이나 자모가 아닌 문자는 그대로 유지한다.
+    """
+
+    def __init__(self) -> None:
+        self._cho_set: frozenset[str] = frozenset(chosung_list)
+        self._jung_set: frozenset[str] = frozenset(jungsung_list)
+        self._jong_set: frozenset[str] = frozenset(jongsung_list) - {" "}
+
+    def normalize(self, s: str) -> str:
+        result = []
+        i = 0
+        n = len(s)
+        while i < n:
+            c = s[i]
+            if c in self._cho_set:
+                if i + 1 < n and s[i + 1] in self._jung_set:
+                    cho, jung = c, s[i + 1]
+                    i += 2
+                    jong = " "
+                    if i < n and s[i] in self._jong_set:
+                        if i + 1 >= n or s[i + 1] not in self._jung_set:
+                            jong = s[i]
+                            i += 1
+                    result.append(compose(cho, jung, jong))
+                else:
+                    result.append(c)
+                    i += 1
+            elif c in self._jung_set:
+                result.append(compose("ㅇ", c, " "))
+                i += 1
+            else:
+                result.append(c)
+                i += 1
+        return "".join(result)
 
 
 class PassCharacterNormalizer(Normalizer):

--- a/tests/unit/test_normalizer.py
+++ b/tests/unit/test_normalizer.py
@@ -3,6 +3,7 @@ import warnings
 from soynlp.normalizer.normalizer import (
     EmojiNormalizer,
     HangleEmojiNormalizer,
+    JamoNormalizer,
     PaddingSpacetoWordsNormalizer,
     PassCharacterNormalizer,
     RemoveLongspaceNormalizer,
@@ -232,3 +233,36 @@ def test_normalize_sent_for_lrgraph():
     assert normalize_sent_for_lrgraph("") == ""
     # 전체가 한글 없는 문장
     assert normalize_sent_for_lrgraph("abc 123") == ""
+
+
+class TestJamoNormalizer:
+    def setup_method(self):
+        self.n = JamoNormalizer()
+
+    def test_basic_jamo_sequence(self):
+        # ㅆㅡㄹㅐㄱㅣ → 쓰래기
+        assert self.n.normalize("ㅆㅡㄹㅐㄱㅣ") == "쓰래기"
+
+    def test_jamo_with_jongsung(self):
+        # ㅆㅣㅂㅏㄹ → 씨발
+        assert self.n.normalize("ㅆㅣㅂㅏㄹ") == "씨발"
+
+    def test_full_word_decomposed(self):
+        # ㅇㅏㄴㄴㅕㅇㅎㅏㅅㅔㅇㅛ → 안녕하세요
+        assert self.n.normalize("ㅇㅏㄴㄴㅕㅇㅎㅏㅅㅔㅇㅛ") == "안녕하세요"
+
+    def test_standalone_consonants_unchanged(self):
+        # 모음이 없는 자음은 그대로
+        assert self.n.normalize("ㅋㅋㅋ") == "ㅋㅋㅋ"
+
+    def test_non_korean_unchanged(self):
+        # 비한글 문자는 그대로
+        assert self.n.normalize("hello 안녕") == "hello 안녕"
+
+    def test_complete_syllables_unchanged(self):
+        # 완성형 한글은 그대로
+        assert self.n.normalize("안녕하세요") == "안녕하세요"
+
+    def test_callable(self):
+        # __call__ 동작
+        assert self.n("ㅆㅡㄹㅐㄱㅣ") == "쓰래기"


### PR DESCRIPTION
## Summary

- `JamoNormalizer(Normalizer)` 클래스 추가
- 연속된 자모 문자 시퀀스를 음절로 재조합 (이슈 #260, #86)
- 예: `ㅆㅡㄹㅐㄱㅣ` → `쓰래기`, `ㅆㅣㅂㅏㄹ` → `씨발`
- 완성형 한글 및 비한글 문자는 그대로 유지
- `soynlp.normalizer.__init__` export 및 단위 테스트(7개) 추가

## 구현

`chosung_list` / `jungsung_list` / `jongsung_list` 기반 상태 기계 알고리즘:
1. 자음(초성 후보) + 모음 → 음절 시작
2. 다음 자음이 모음 앞에 오면 종성 없이 마감, 아니면 종성 처리
3. 모음만 단독 등장 시 ㅇ을 초성으로 사용

## Test plan

- [x] pre-commit (pyright + ruff lint + ruff format) 통과
- [x] `uv run pytest tests/unit/test_normalizer.py` 통과