### PR TITLE
perf(hangle): decompose()에 lru_cache 추가 — lemma_candidate 속도 개선 (#266)

### DIFF
--- a/soynlp/hangle/hangle.py
+++ b/soynlp/hangle/hangle.py
@@ -1,4 +1,5 @@
 import re
+from functools import lru_cache
 
 import numpy as np
 
@@ -167,6 +168,7 @@ def compose(chosung: str, jungsung: str, jongsung: str) -> str:
     )
 
 
+@lru_cache(maxsize=12288)
 def decompose(c: str) -> tuple[str, str, str] | None:
     if not character_is_korean(c):
         return None


### PR DESCRIPTION
## Summary

- `soynlp.hangle.decompose()`에 `@lru_cache(maxsize=12288)` 추가 (이슈 #266, #85)
- 동일 문자에 대한 반복 분해 연산을 캐시로 제거

## 벤치마크 결과

| 지표 | before | after | 개선율 |
|------|--------|-------|--------|
| lemma_candidate 평균 | 32.5μs | 18.1μs | **-44%** |
| 함수 호출 횟수(3000회 기준) | 1,011,007 | 411,197 | **-59%** |

## 구현

한글 음절은 약 11,172종으로 `maxsize=12288`이면 거의 100% 캐시 적중.
`decompose`는 순수 함수이므로 캐싱이 안전하다.

## Test plan

- [x] pre-commit (pyright + ruff) 통과
- [x] `uv run pytest tests/unit/` 전체 370개 통과