### PR TITLE
style(tokenizer): _tokenize % 포매팅을 f-string으로 변환

### DIFF
--- a/soynlp/tokenizer/tokenizer.py
+++ b/soynlp/tokenizer/tokenizer.py
@@ -131,7 +131,7 @@ class RegexTokenizer:
                 if begin > i:
                     continue
                 if s[i : i + len_found] == found:
-                    s_ += " %s " % s[i : i + len_found]
+                    s_ += f" {s[i : i + len_found]} "
                     begin = i + len_found
                     if not founds:
                         s_ += s[begin:]


### PR DESCRIPTION
## Summary

- `RegexTokenizer._tokenize` 내 `%` 포매팅을 f-string으로 변환

## 관련 이슈

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)