### PR TITLE
fix(tokenizer): _tokenize 빈 문자열 입력 시 IndexError 방어 가드 추가

### DIFF
--- a/soynlp/tokenizer/tokenizer.py
+++ b/soynlp/tokenizer/tokenizer.py
@@ -131,7 +131,7 @@ class RegexTokenizer:
                 if begin > i:
                     continue
                 if s[i : i + len_found] == found:
-                    s_ += " %s " % s[i : i + len_found]
+                    s_ += f" {s[i : i + len_found]} "
                     begin = i + len_found
                     if not founds:
                         s_ += s[begin:]

--- a/soynlp/tokenizer/tokenizer.py
+++ b/soynlp/tokenizer/tokenizer.py
@@ -143,6 +143,8 @@ class RegexTokenizer:
                 s_ += char
             s = s_
         words = self.doublewhite_pattern.sub(" ", s).strip().split()
+        if not words:
+            return []
         r = len(words[0])
         tokens = [Token(words[0], 0 + offset, r + offset, 1, r, eojeol_id)]
         begin = tokens[0].end

--- a/tests/unit/test_tokenizers.py
+++ b/tests/unit/test_tokenizers.py
@@ -4,6 +4,12 @@ from soynlp.tokenizer import LTokenizer, MaxScoreTokenizer, RegexTokenizer
 from soynlp.tokenizer.tokenizer_builder import EojeolPatternTrainer
 
 
+def test_regex_tokenizer_empty_string():
+    tokenizer = RegexTokenizer()
+    assert tokenizer.tokenize("") == []
+    assert tokenizer.tokenize("   ") == []
+
+
 def test_regex_tokenizer():
     sentence = "abc123가나다 alphabet!!3.14한글 hank`s report"
     expected_words = ["abc", "123", "가나다", "alphabet", "!!", "3.14", "한글", "hank`s", "report"]


### PR DESCRIPTION
## Summary

- `_tokenize`에 빈 문자열·공백 전용 입력 시 `words[0]` IndexError 방어 가드 추가
- 단위 테스트 2개 추가 (`""`, `"   "` 입력 케이스)

## 관련 이슈

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)