### PR TITLE
fix(tokenizer): 숫자 패턴이 버전 번호(3.1.1)를 잘못 분리하는 버그 수정

### DIFF
--- a/soynlp/tokenizer/tokenizer.py
+++ b/soynlp/tokenizer/tokenizer.py
@@ -66,7 +66,7 @@ class RegexTokenizer:
 
     def _default_pipelines(self):
         return [
-            re.compile(r"[-+]?\d*[\.]?[\d]+|[-+]?\d+", re.UNICODE),  # number
+            re.compile(r"[-+]?\d+(?:\.\d+)*", re.UNICODE),  # number (int, decimal, version: 3.1.1)
             re.compile(r"[가-힣]+", re.UNICODE),  # Korean
             re.compile(r"[ㄱ-ㅎ]+", re.UNICODE),  # jaum
             re.compile(r"[ㅏ-ㅣ]+", re.UNICODE),  # moum

--- a/tests/unit/test_tokenizers.py
+++ b/tests/unit/test_tokenizers.py
@@ -10,6 +10,15 @@ def test_regex_tokenizer_empty_string():
     assert tokenizer.tokenize("   ") == []
 
 
+def test_regex_tokenizer_version_number():
+    tokenizer = RegexTokenizer()
+    # 버전 번호(3.1.1)가 하나의 토큰으로 분리되어야 한다 (issue #7)
+    assert tokenizer.tokenize("다음에는3.1.1장입니다") == ["다음에는", "3.1.1", "장입니다"]
+    assert tokenizer.tokenize("v1.2.3.4릴리스") == ["v", "1.2.3.4", "릴리스"]
+    assert tokenizer.tokenize("3.14") == ["3.14"]
+    assert tokenizer.tokenize("42") == ["42"]
+
+
 def test_regex_tokenizer():
     sentence = "abc123가나다 alphabet!!3.14한글 hank`s report"
     expected_words = ["abc", "123", "가나다", "alphabet", "!!", "3.14", "한글", "hank`s", "report"]


### PR DESCRIPTION
## Summary

- `_default_pipelines`의 숫자 정규식이 소수점 최대 1개만 허용하여 `3.1.1`을 `['3.1', '.1']`로 잘못 분리하던 버그 수정
- `[-+]?\d*[\.]?[\d]+|[-+]?\d+` → `[-+]?\d+(?:\.\d+)*`

## 변경 전/후

```python
# 변경 전
tokenize('다음에는3.1.1장입니다') → ['다음에는', '3.1', '.1', '장입니다']  ❌

# 변경 후
tokenize('다음에는3.1.1장입니다') → ['다음에는', '3.1.1', '장입니다']  ✓
```

## 관련 이슈

Closes #279
Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)