### PR TITLE
fix(tokenizer): tokenize offset 계산이 다중 공백에서 틀리는 버그 수정

### DIFF
--- a/soynlp/tokenizer/tokenizer.py
+++ b/soynlp/tokenizer/tokenizer.py
@@ -108,11 +108,9 @@ class RegexTokenizer:
                Token(hank`s, score=1, position=(27, 33), eojeol_id=2),
                Token(report, score=1, position=(34, 40), eojeol_id=3)]
         """
-        offset = 0
         tokens = []
-        for eojeol_id, token in enumerate(sentence.split()):
-            tokens += self._tokenize(token, offset, eojeol_id)
-            offset += len(token) + 1
+        for eojeol_id, m in enumerate(re.finditer(r"\S+", sentence)):
+            tokens += self._tokenize(m.group(), m.start(), eojeol_id)
         if return_words:
             tokens = [token.word for token in tokens]
         return tokens

--- a/tests/unit/test_tokenizers.py
+++ b/tests/unit/test_tokenizers.py
@@ -4,6 +4,7 @@ from soynlp.tokenizer import LTokenizer, MaxScoreTokenizer, NounMatchTokenizer, 
 from soynlp.tokenizer.tokenizer_builder import EojeolPatternTrainer
 
 
+<<<<<<< HEAD
 def test_regex_tokenizer_empty_string():
     tokenizer = RegexTokenizer()
     assert tokenizer.tokenize("") == []
@@ -17,6 +18,14 @@ def test_regex_tokenizer_version_number():
     assert tokenizer.tokenize("v1.2.3.4릴리스") == ["v", "1.2.3.4", "릴리스"]
     assert tokenizer.tokenize("3.14") == ["3.14"]
     assert tokenizer.tokenize("42") == ["42"]
+
+
+def test_regex_tokenizer_multi_space_offset():
+    # 연속 공백이 있을 때 Token의 position이 정확해야 한다 (issue #280)
+    tokenizer = RegexTokenizer()
+    tokens = tokenizer.tokenize("hello  world", return_words=False)
+    assert tokens[0].word == "hello" and tokens[0].begin == 0 and tokens[0].end == 5
+    assert tokens[1].word == "world" and tokens[1].begin == 7 and tokens[1].end == 12
 
 
 def test_regex_tokenizer():


### PR DESCRIPTION
## Summary

- `sentence.split()` + `offset += len(token) + 1` 조합이 연속 공백 시 `Token.begin/end` 오류를 발생시키던 버그 수정
- `re.finditer(r'\S+', sentence)`로 교체하여 각 eojeol의 실제 위치를 직접 추출

## 변경 전/후

```python
# 변경 전
tokenize('hello  world', return_words=False)
# Token(world, begin=6, ...)  ← 실제 위치는 7  ❌

# 변경 후
tokenize('hello  world', return_words=False)
# Token(world, begin=7, ...)  ✓
```

## 관련 이슈

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)