### PR TITLE
fix(word): get_entropy 전부 0인 리스트 입력 시 ZeroDivisionError 방어 가드 추가

### DIFF
--- a/soynlp/word/word.py
+++ b/soynlp/word/word.py
@@ -371,6 +371,8 @@ def get_entropy(collection_of_numbers: list[int] | list[float]) -> float:
     if not collection_of_numbers:
         return 0.0
     total = sum(collection_of_numbers)
+    if total == 0:
+        return 0.0
     entropy = 0
     for number in collection_of_numbers:
         prob = float(number) / total

--- a/tests/unit/test_wordextractor.py
+++ b/tests/unit/test_wordextractor.py
@@ -212,6 +212,15 @@ def test_get_entropy(counts, expected):
     assert abs(get_entropy(counts) - expected) < 0.0001
 
 
+def test_get_entropy_all_zeros():
+    # 전부 0인 리스트 → ZeroDivisionError 없이 0.0 반환
+    assert get_entropy([0, 0, 0]) == 0.0
+
+
+def test_get_entropy_empty():
+    assert get_entropy([]) == 0.0
+
+
 # --- WordExtractor multiprocessing tests ---
 
 _WORD_SENTS = [


### PR DESCRIPTION
## Summary

- `total == 0`이면 `0.0` 반환하는 가드 추가
- 단위 테스트 2개 추가: `[0, 0, 0]`, `[]`

## 관련 이슈

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)