### PR TITLE
fix(tokenizer): LTokenizer/MaxScoreTokenizer/NounMatchTokenizer offset 버그 수정

### DIFF
--- a/soynlp/tokenizer/tokenizer.py
+++ b/soynlp/tokenizer/tokenizer.py
@@ -228,9 +228,10 @@ class LTokenizer:
                 best = max(candidates, key=lambda x: (x[0], len(x[1])))
             return best
 
-        offset = 0
         tokens = []
-        for eojeol_id, s in enumerate(sentence.split()):
+        for eojeol_id, m in enumerate(re.finditer(r"\S+", sentence)):
+            s = m.group()
+            offset = m.start()
             score, l, r = token_to_lr(s)  # noqa: E741
             len_l, len_r = len(l), len(r)
             tokens.append(
@@ -239,7 +240,6 @@ class LTokenizer:
                     Token(r, offset + len_l, offset + len_l + len_r, 0, len_r, eojeol_id),
                 ]
             )
-            offset += len_l + len_r + 1
 
         if remove_r:
             tokens = [l.word for l, r in tokens]  # noqa: E741
@@ -311,11 +311,9 @@ class MaxScoreTokenizer:
         Returns:
             tokens (list of str or list of Token)
         """
-        offset = 0
         tokens = []
-        for eojeol_id, s in enumerate(sentence.split()):
-            tokens += self._tokenize_eojeol(s, offset, eojeol_id)
-            offset += len(s) + 1
+        for eojeol_id, m in enumerate(re.finditer(r"\S+", sentence)):
+            tokens += self._tokenize_eojeol(m.group(), m.start(), eojeol_id)
         if return_words:
             tokens = [token.word for token in tokens]
         return tokens
@@ -473,9 +471,9 @@ class NounMatchTokenizer(MaxScoreTokenizer):
                 concats.append(Token(eojeol[begin - offset : end - offset], begin, end, score, end - begin, eojeol_id))
             return concats
 
-        offset = 0
         tokens = []
-        for eojeol_id, s in enumerate(sentence.split()):
+        for eojeol_id, m in enumerate(re.finditer(r"\S+", sentence)):
+            s, offset = m.group(), m.start()
             nouns = self._tokenize_eojeol(s, offset, eojeol_id)
             nouns = [noun for noun in nouns if noun.score > 0]
             if concat_compound:
@@ -486,7 +484,6 @@ class NounMatchTokenizer(MaxScoreTokenizer):
                 else:
                     nouns = nouns[:1]
             tokens += nouns
-            offset += len(s) + 1
         if return_words:
             tokens = [token.word for token in tokens]
         return tokens

--- a/tests/unit/test_tokenizers.py
+++ b/tests/unit/test_tokenizers.py
@@ -1,6 +1,6 @@
 import pytest
 
-from soynlp.tokenizer import LTokenizer, MaxScoreTokenizer, RegexTokenizer
+from soynlp.tokenizer import LTokenizer, MaxScoreTokenizer, NounMatchTokenizer, RegexTokenizer
 from soynlp.tokenizer.tokenizer_builder import EojeolPatternTrainer
 
 
@@ -56,6 +56,35 @@ def test_l_tokenizer(scores, sentence, tolerance, remove_r, expected):
     tokenizer = LTokenizer(scores)
     words = tokenizer.tokenize(sentence, tolerance=tolerance, remove_r=remove_r)
     assert words == expected
+
+
+def test_l_tokenizer_multi_space_offset():
+    scores = {"파스타": 0.7, "좋아": 0.3}
+    tokenizer = LTokenizer(scores)
+    tokens = tokenizer.tokenize("파스타가  좋아요", return_words=False)
+    words = [t.word for t in tokens if t.length > 0]
+    begins = {t.word: t.begin for t in tokens if t.length > 0}
+    assert "파스타" in words
+    assert begins["파스타"] == 0
+    assert begins.get("좋아요") == 6 or begins.get("좋아") == 6
+
+
+def test_maxscore_tokenizer_multi_space_offset():
+    scores = {"파스타": 0.7, "좋아": 0.3}
+    tokenizer = MaxScoreTokenizer(scores)
+    tokens = tokenizer.tokenize("파스타가  좋아요", return_words=False)
+    begins = {t.word: t.begin for t in tokens}
+    assert begins.get("파스타") == 0
+    assert begins.get("좋아") == 6
+
+
+def test_noun_match_tokenizer_multi_space_offset():
+    nouns = {"파스타", "좋아"}
+    tokenizer = NounMatchTokenizer(nouns)
+    tokens = tokenizer.tokenize("파스타가  좋아요", return_words=False)
+    begins = {t.word: t.begin for t in tokens}
+    assert begins.get("파스타") == 0
+    assert begins.get("좋아") == 6
 
 
 def test_maxscore_tokenizer():


### PR DESCRIPTION
## Summary

PR #280에서 `RegexTokenizer`만 수정했던 `offset += len + 1` 버그를 나머지 3개 클래스에도 동일하게 수정.

- `LTokenizer.tokenize`
- `MaxScoreTokenizer.tokenize`
- `NounMatchTokenizer.tokenize`

모두 `re.finditer(r'\S+', sentence)`로 교체하여 실제 위치 추출.
다중 공백 시 position 정확성 단위 테스트 3개 추가.

## 관련 이슈

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)