### PR TITLE
refactor(noun): compounds_components dict 타입 파라미터 추가

### DIFF
--- a/soynlp/noun/lr.py
+++ b/soynlp/noun/lr.py
@@ -125,7 +125,7 @@ class LRNounExtractor:
         logger.info(f"#pos={len(self.pos)}, #neg={len(self.neg)}, #common={len(self.common)}")
 
         self.lrgraph: LRGraph | None = None
-        self.compounds_components: dict | None = None
+        self.compounds_components: dict[str, tuple[str, ...]] | None = None
         self.compound_decomposer: MaxScoreTokenizer | None = None
         self.nouns: dict[str, NounScore] | None = None
 


### PR DESCRIPTION
## Summary

- `self.compounds_components: dict | None` → `dict[str, tuple[str, ...]] | None`

## 관련 이슈

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)