### PR TITLE
fix(word): calculate_branching_entropy max() 빈 시퀀스 방어 가드 추가

### DIFF
--- a/soynlp/word/word.py
+++ b/soynlp/word/word.py
@@ -406,7 +406,7 @@ def calculate_branching_entropy_accessor_variety_batch(
     av_r: dict[str, int] = {}
 
     offset = 0
-    max_l_length = max(l_groupby_len)
+    max_l_length = max(l_groupby_len, default=0)
     for l_len, l_count in sorted(l_groupby_len.items()):
         if l_len == 1:
             continue
@@ -439,7 +439,7 @@ def calculate_branching_entropy_accessor_variety_batch(
         offset += len(l_count)
 
     offset = 0
-    max_r_length = max(r_groupby_len)
+    max_r_length = max(r_groupby_len, default=0)
     for r_len, r_count in sorted(r_groupby_len.items()):
         if r_len == 1:
             continue


### PR DESCRIPTION
## Summary

`calculate_branching_entropy_accessor_variety_batch` 함수에서 `L` 또는 `R`이 비어 있을 때 `max(l_groupby_len)` 호출로 `ValueError` 발생 가능.

`max(l_groupby_len, default=0)` 패턴으로 수정해 빈 입력 시 안전하게 동작하도록 개선.

## 관련 이슈

Close #308

## Test plan

- [ ] `uv run pyright soynlp/word/` — 0 errors
- [ ] `uv run pytest tests/unit/test_wordextractor.py` — 19 passed